### PR TITLE
Extra flexibility to the Grid class

### DIFF
--- a/dlup/data/dataset.py
+++ b/dlup/data/dataset.py
@@ -139,7 +139,7 @@ class BaseSlideImageDataset(Dataset):
 
         slide_image = self.slide_image
         slide_level_size = slide_image.get_scaled_size(slide_image.mpp / mpp)
-        self._grid = Grid.create(slide_level_size, tile_size, tile_overlap=tile_overlap, mode=tile_mode)
+        self._grid = Grid.from_tiling((0, 0), slide_level_size, tile_size, tile_overlap=tile_overlap, mode=tile_mode)
         self._tile_size = tile_size
 
     @staticmethod

--- a/dlup/tiling.py
+++ b/dlup/tiling.py
@@ -115,32 +115,29 @@ class Grid:
 
     def __init__(self, coordinates: List[np.ndarray]):
         """Initialize a lattice given a set of basis vectors."""
-        self._coordinates = coordinates
-        self._size = tuple(len(x) for x in self._coordinates)
+        self.coordinates = coordinates
 
     @classmethod
-    def create(
+    def from_tiling(
         cls,
+        offset: _GenericNumberArray,
         size: _GenericNumberArray,
         tile_size: _GenericNumberArray,
         tile_overlap: Union[_GenericNumberArray, _GenericNumber] = 0,
         mode: TilingMode = TilingMode.skip,
     ):
-        """Main method to create a Lattice object."""
-        return cls(tiles_grid_coordinates(size, tile_size, tile_overlap, mode))
+        """Generate a grid from a set of tiling parameters."""
+        coordinates = tiles_grid_coordinates(size, tile_size, tile_overlap, mode)
+        coordinates = [c + o for c, o in zip(coordinates, offset)]
+        return cls(coordinates)
 
     @property
     def size(self) -> Tuple[int, ...]:
         """Return the size of the generated lattice."""
-        return self._size
-
-    @property
-    def coordinates(self) -> List[np.ndarray]:
-        """Returns the coordinates vectors generating the grid."""
-        return self._coordinates
+        return tuple(len(x) for x in self.coordinates)
 
     def __getitem__(self, i) -> np.ndarray:
-        index = np.unravel_index(i, self._size)
+        index = np.unravel_index(i, self.size)
         return np.array(list(c[i] for c, i in zip(self.coordinates, index)))
 
     def __len__(self) -> int:


### PR DESCRIPTION
o Added support for an extra parameter during Grid() creation to specify a global offset for
every coordinate.
o Improved naming and docstring

Example:

```
from dlup.data.dataset import SlideImageDataset
from dlup import SlideImage
from dlup.tiling import Grid
import matplotlib.pyplot as plt
from PIL import Image, ImageDraw
import numpy as np

INPUT_FILE_PATH = "TCGA-B6-A0IG-01Z-00-DX1.4238CB6E-0561-49FD-9C49-9B8AEAFC4618.svs"
slide_image = SlideImage.from_file_path(INPUT_FILE_PATH)

TARGET_MPP = 100

# Level 0 mpp image units
ROI_SIZE = (30000, 20000)
ROI_COORDINATES = (100000, 50000)

# Target mpp image units
TILE_SIZE = (10, 10)

scaling = slide_image.mpp / TARGET_MPP
roi_scaled_coordinates = np.array(ROI_COORDINATES) * scaling
roi_scaled_size = np.array(ROI_SIZE) * scaling

grid = Grid.from_tiling(roi_scaled_coordinates, roi_scaled_size, TILE_SIZE, (0, 0))
scaled_region_view = slide_image.get_scaled_view(scaling)

background = Image.new('RGBA', tuple(scaled_region_view.size), (255, 255, 255, 255))

for coords in grid:
    tile = scaled_region_view.read_region(coords, TILE_SIZE)
    pil_image = Image.fromarray(tile)
    box = tuple(np.array((*coords, *(coords + TILE_SIZE))).astype(int))
    background.paste(pil_image, box)
    draw = ImageDraw.Draw(background)
    draw.rectangle(box, outline='red')

plt.figure()
plt.imshow(background)
plt.show()
````

Result:

![image](https://user-images.githubusercontent.com/1597330/128342791-639c81ea-4518-4fc6-aad2-7caf0d1b5b4c.png)

What do you think @jonasteuwen ,  @Baggsy ?