### PR TITLE
Multiscale dataset

### DIFF
--- a/dlup/data/dataset.py
+++ b/dlup/data/dataset.py
@@ -5,7 +5,6 @@
 Dataset and ConcatDataset are taken from pytorch 1.8.0 under BSD license.
 """
 
-import abc
 import bisect
 import collections
 import functools
@@ -16,7 +15,7 @@ from typing import Callable, Generic, Iterable, List, Optional, Tuple, TypedDict
 
 import numpy as np
 import PIL
-from numpy.typing import ArrayLike, NDArray
+from numpy.typing import NDArray
 from PIL import Image
 
 from dlup import BoundaryMode, SlideImage
@@ -336,7 +335,7 @@ class TiledROIsSlideImageDataset(SlideImageDatasetBase[RegionFromSlideDatasetSam
         mask_threshold :
             0 every region is discarded, 1 requires the whole region to be foreground.
         transform :
-            Tansform to be applied to the sample
+            Transform to be applied to the sample.
 
         Example
         -------

--- a/dlup/data/dataset.py
+++ b/dlup/data/dataset.py
@@ -182,7 +182,7 @@ class SlideImageDatasetBase(Dataset[T_co]):
         # Then masked_indices[0] == 0, masked_indices[1] == 2.
         self.masked_indices: Union[NDArray[np.int_], None] = None
         if mask is not None:
-            boolean_mask: NDArray[np.bool_] = np.zeros(len(regions))
+            boolean_mask: NDArray[np.bool_] = np.zeros(len(regions), dtype=bool)
             for i, region in enumerate(regions):
                 boolean_mask[i] = is_foreground(self.slide_image, mask, region, mask_threshold)
             self.masked_indices = np.argwhere(boolean_mask).flatten()
@@ -253,7 +253,7 @@ class SlideImageDataset(SlideImageDatasetBase[StandardTilingFromSlideDatasetSamp
 
 def _coords_to_region(tile_size, target_mpp, key, coords):
     """Return the necessary tuple that represents a region."""
-    return (*coords, *tile_size, target_mpp)
+    return *coords, *tile_size, target_mpp
 
 
 class TiledROIsSlideImageDataset(SlideImageDatasetBase[RegionFromSlideDatasetSample]):

--- a/dlup/data/experimental/__init__.py
+++ b/dlup/data/experimental/__init__.py
@@ -1,0 +1,2 @@
+# coding=utf-8
+# Copyright (c) dlup contributors

--- a/dlup/data/experimental/dataset.py
+++ b/dlup/data/experimental/dataset.py
@@ -12,7 +12,7 @@ from dlup.data.dataset import TiledROIsSlideImageDataset
 from dlup.tiling import Grid, TilingMode
 
 
-class MultiScaleTiledROIsSlideImageDataset(TiledROIsSlideImageDataset):
+class MultiScaleSlideImageDataset(TiledROIsSlideImageDataset):
     """Dataset class that supports multiscale output, and can have multiple ROIs.
 
     This dataset can be used, for example, to tile your WSI on-the-fly using the `multiscale_from_tiling` function.
@@ -20,7 +20,7 @@ class MultiScaleTiledROIsSlideImageDataset(TiledROIsSlideImageDataset):
 
     Example
     -------
-    >>>  dlup_dataset = MultiScaleTiledROIsSlideImageDataset.multiscale_from_tiling(\
+    >>>  dlup_dataset = MultiScaleSlideImageDataset.multiscale_from_tiling(\
             path="/path/to/TCGA-WSI.svs",\
             mpps=[0.0625, 0.125],\
             tile_size=(1024, 1024),\

--- a/dlup/data/experimental/dataset.py
+++ b/dlup/data/experimental/dataset.py
@@ -3,7 +3,7 @@
 """Experimental dataset functions, might e.g. lack tests, or requires input from users"""
 
 import pathlib
-from typing import Callable, Iterable, List, Optional, Tuple, Sequence
+from typing import Callable, Iterable, List, Optional, Sequence, Tuple
 
 import numpy as np
 

--- a/dlup/data/experimental/dataset.py
+++ b/dlup/data/experimental/dataset.py
@@ -1,0 +1,131 @@
+# coding=utf-8
+# Copyright (c) dlup contributors
+"""Experimental dataset functions, might e.g. lack tests, or requires input from users"""
+
+import pathlib
+from typing import Iterable, Tuple, Optional, Callable, List
+
+import numpy as np
+
+from dlup import SlideImage
+from dlup.data.dataset import TiledROIsSlideImageDataset
+from dlup.tiling import Grid, TilingMode
+
+
+class MultiScaleTiledROIsSlideImageDataset(TiledROIsSlideImageDataset):
+    """Dataset class that supports multiscale output, and can have multiple ROIs.
+
+    This dataset can be used, for example, to tile your WSI on-the-fly using the `multiscale_from_tiling` function.
+    The output of the dataset will be provided as a list of dictionaries as outputs of `TiledROIsSlideImageDataset`
+
+    Example
+    -------
+    >>>  dlup_dataset = MultiScaleTiledROIsSlideImageDataset.multiscale_from_tiling(\
+            path="/path/to/TCGA-WSI.svs",\
+            mpps=[0.0625, 0.125],\
+            tile_size=(1024, 1024),\
+            tile_overlap=(512, 512),\
+            tile_mode=TilingMode.skip,\
+            crop=True,\
+            mask=None,\
+            mask_threshold=0.5,\
+            transform=YourTransform()\
+         )
+    >>> sample = dlup_dataset[5]
+    >>> images = (sample[0]["image"], sample[1]["image"])
+    """
+    def __init__(
+        self,
+        path: pathlib.Path,
+        grids: Iterable[Tuple[Grid, Tuple[int, int], float]],
+        num_scales: int,
+        crop: bool = True,
+        mask: Optional[np.ndarray] = None,
+        mask_threshold: float = 0.1,
+        transform: Optional[Callable] = None,
+    ):
+        self._grids = grids
+        self._num_scales = num_scales
+        if len(list(grids)) % num_scales != 0:
+            raise ValueError(f"In a multiscale dataset the grids needs to be divisible by the number of scales.")
+
+        self._step_size = len(grids[0][0])
+        self._index_ranges = [
+            range(idx * self._step_size, (idx + 1) * self._step_size) for idx in range(0, num_scales)
+        ]
+        super().__init__(path, grids, crop, mask=mask, mask_threshold=mask_threshold, transform=None)
+        self.__transform = transform
+
+    def __len__(self):
+        return self._step_size
+
+    @classmethod
+    def multiscale_from_tiling(
+        cls,
+        path: pathlib.Path,
+        mpps: List[float],
+        tile_size: Tuple[int, int],
+        tile_overlap: Tuple[int, int],
+        tile_mode: TilingMode = TilingMode.skip,
+        crop: bool = True,
+        mask: Optional[np.ndarray] = None,
+        rois: Optional = None,
+        mask_threshold: float = 0.1,
+        transform: Optional[Callable] = None,
+    ):
+
+        if mpps != sorted(mpps):
+            raise ValueError(f"The mpp values should be in increasing order.")
+
+        with SlideImage.from_file_path(path) as slide_image:
+            original_mpp = slide_image.mpp
+            original_size = slide_image.size
+            if rois is None:
+                rois = [[0, 0, *original_size]]
+            else:
+                # Do some checks whether the ROIs are within the image
+                origin_positive = [np.all(np.asarray(_[:2]) > 0) for _ in rois]
+                image_within_borders = [np.all((np.asarray(_[:2]) + _[2:]) <= original_size) for _ in rois]
+                if not origin_positive or not image_within_borders:
+                    raise ValueError(f"ROIs should be within image boundaries. Got {rois}.")
+
+        view_scalings = [mpp / original_mpp for mpp in mpps]
+        grids = []
+        for scaling in view_scalings:
+            for roi in rois:
+                offset = roi[:2]
+                size = roi[2:]
+
+                # We CEIL the offset and FLOOR the size, so that we are always in a fully annotated area.
+                offset = np.ceil(offset).astype(int)
+                size = np.floor(size).astype(int)
+
+                curr_tile_overlap = (np.asarray(tile_size)) * (scaling - 1) / scaling
+                curr_offset = (offset - np.asarray(tile_size) * (scaling - 1) / 2) / scaling
+                curr_grid = Grid.from_tiling(
+                    curr_offset,
+                    size=size / scaling + curr_tile_overlap,
+                    tile_size=tile_size,
+                    tile_overlap=curr_tile_overlap + np.asarray(tile_overlap) / scaling,
+                    mode=tile_mode,
+                )
+
+                grids.append((curr_grid, tile_size, original_mpp * scaling))
+
+        return cls(
+            path,
+            grids,
+            num_scales=len(view_scalings),
+            crop=crop,
+            mask=mask,
+            mask_threshold=mask_threshold,
+            transform=transform,
+        )
+
+    def __getitem__(self, index):
+        indices = [_[index] for _ in self._index_ranges]
+        sample = [TiledROIsSlideImageDataset.__getitem__(self, _) for _ in indices]
+        if self.__transform:
+            sample = self.__transform(sample)
+
+        return sample

--- a/dlup/tiling.py
+++ b/dlup/tiling.py
@@ -4,11 +4,10 @@
 import collections
 import functools
 from enum import Enum
-from typing import Iterator, List, Sequence, Tuple, Type, TypeVar, Union
+from typing import Iterator, List, Sequence, Tuple, Union
 
 import numpy as np
-
-from ._region import RegionView
+from numpy.typing import NDArray
 
 _GenericNumber = Union[int, float]
 _GenericNumberArray = Union[np.ndarray, Sequence[_GenericNumber]]
@@ -91,7 +90,7 @@ def tiles_grid_coordinates(
         overflow = tiled_size - size
 
     # Let's create our indices list
-    coordinates = []
+    coordinates: List[NDArray[np.float_]] = []
     for n, dstride, dtile_size, doverflow, dsize in zip(num_tiles, stride, tile_size, overflow, size):
         tiles_locations = np.arange(n) * dstride
 


### PR DESCRIPTION
This PR adds support for multiscale datasets. Instead of setting one mpp, you can set multiple and tiles of the same sizes will be generated with the lowest resolution tile always in the middle.

Currently in an `experimental` module as it will require input from users (and subsequent tests).