### PR TITLE
Use max dimension to compute scaling for background

### DIFF
--- a/dlup/_image.py
+++ b/dlup/_image.py
@@ -61,7 +61,7 @@ class _SlideImageRegionView(RegionView):
         return self._wsi.read_region((x, y), self._scaling, (w, h))
 
 
-def _clip2size(a: np.ndarray, size: Tuple[_GenericNumber, _GenericNumber]) -> Sequence[_GenericNumber]:
+def _clip2size(a: np.ndarray, size: Tuple[_GenericNumber, _GenericNumber]) -> np.ndarray:
     """Clip values from 0 to size boundaries."""
     return np.clip(a, (0, 0), size)
 

--- a/dlup/background.py
+++ b/dlup/background.py
@@ -226,7 +226,12 @@ def is_foreground(
     background_mask = PIL.Image.fromarray(background_mask)
 
     # Type of background_mask is Any here.
-    scaling = background_mask.width / region_view.size[0]  # type: ignore
+    # The scaling should be computed using the longest edge of the image.
+    background_size = (background_mask.width, background_mask.height)  # type: ignore
+
+    region_size = region_view.size
+    max_dimension_index = max(range(len(background_size)), key=background_size.__getitem__)
+    scaling = background_size[max_dimension_index] / region_size[max_dimension_index]
     scaled_region = np.array((x, y, w, h)) * scaling
     scaled_coordinates, scaled_sizes = scaled_region[:2], scaled_region[2:].astype(int)
 


### PR DESCRIPTION
The scaling value between the foreground mask and the image is currently computing using image width. This is inconsistent compared to the way the mask is generated. This PR fixes this problem by using the max value.