### PR TITLE
Fix tiff size order

### DIFF
--- a/dlup/writers.py
+++ b/dlup/writers.py
@@ -62,7 +62,7 @@ class TifffileImageWriter(ImageWriter):
     def __init__(
         self,
         filename: PathLike,
-        size: Union[Tuple[int, int, int], Tuple[int, int]],
+        size: Union[Tuple[int, int], Tuple[int, int, int]],
         mpp: Union[float, Tuple[float, float]],
         tile_size: Tuple[int, int] = (512, 512),
         pyramid: bool = False,
@@ -92,7 +92,8 @@ class TifffileImageWriter(ImageWriter):
         """
         self._filename = pathlib.Path(filename)
         self._tile_size = tile_size
-        self._size = (*size[::-1], 1) if len(size) == 2 else (size[1], size[0], size[2])
+
+        self._size = (*size[::-1], 1) if len(size) == 2 else (size[1], size[0], size[2])  # type: ignore
         self._mpp: Tuple[float, float] = (mpp, mpp) if isinstance(mpp, float) else mpp
 
         if not compression:

--- a/dlup/writers.py
+++ b/dlup/writers.py
@@ -92,7 +92,7 @@ class TifffileImageWriter(ImageWriter):
         """
         self._filename = pathlib.Path(filename)
         self._tile_size = tile_size
-        self._size = (*size, 1) if len(size) == 2 else size
+        self._size = (*size[::-1], 1) if len(size) == 2 else size[::-1]
 
         if isinstance(mpp, float):
             mpp = (mpp, mpp)

--- a/dlup/writers.py
+++ b/dlup/writers.py
@@ -92,7 +92,7 @@ class TifffileImageWriter(ImageWriter):
         """
         self._filename = pathlib.Path(filename)
         self._tile_size = tile_size
-        self._size = (*size[::-1], 1) if len(size) == 2 else size[::-1]
+        self._size = (*size[::-1], 1) if len(size) == 2 else (size[1], size[0], size[2])
         self._mpp: Tuple[float, float] = (mpp, mpp) if isinstance(mpp, float) else mpp
 
         if not compression:

--- a/dlup/writers.py
+++ b/dlup/writers.py
@@ -93,10 +93,7 @@ class TifffileImageWriter(ImageWriter):
         self._filename = pathlib.Path(filename)
         self._tile_size = tile_size
         self._size = (*size[::-1], 1) if len(size) == 2 else size[::-1]
-
-        if isinstance(mpp, float):
-            mpp = (mpp, mpp)
-        self._mpp: Tuple[float, float] = mpp
+        self._mpp: Tuple[float, float] = (mpp, mpp) if isinstance(mpp, float) else mpp
 
         if not compression:
             compression = TiffCompression.NONE

--- a/docs/writers.rst
+++ b/docs/writers.rst
@@ -23,7 +23,7 @@ Example code
     mask = SlideImage.from_file_path(path, backend=ImageBackends.TIFFFILE)
     writer = TifffileImageWriter(
         filename=output_file,
-        size=(*mask.size[::-1], 3),
+        size=(*mask.size, 3),
         tile_size=(512, 512),
         mpp=mask.mpp,
         compression=TiffCompression.JPEG,

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -22,9 +22,7 @@ def test_tiff_writer(shape):
         size = (*pil_image.size, 3)
 
     with tempfile.NamedTemporaryFile(suffix=".tiff") as temp_tiff:
-        writer = TifffileImageWriter(
-            temp_tiff.name, size=size, mpp=(0.45, 0.45), compression=TiffCompression.NONE
-        )
+        writer = TifffileImageWriter(temp_tiff.name, size=size, mpp=(0.45, 0.45), compression=TiffCompression.NONE)
 
         writer.from_pil(pil_image)
         vips_image = pyvips.Image.new_from_file(temp_tiff.name)

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -16,9 +16,14 @@ def test_tiff_writer(shape):
     random_array = np.random.randint(low=0, high=255, size=(1200, 1200, 3), dtype=np.uint8)
     pil_image = PIL.Image.fromarray(random_array)
 
+    if pil_image.mode == "L":
+        size = pil_image.size
+    else:
+        size = (*pil_image.size, 3)
+
     with tempfile.NamedTemporaryFile(suffix=".tiff") as temp_tiff:
         writer = TifffileImageWriter(
-            temp_tiff.name, size=np.asarray(pil_image).shape, mpp=(0.45, 0.45), compression=TiffCompression.NONE
+            temp_tiff.name, size=size, mpp=(0.45, 0.45), compression=TiffCompression.NONE
         )
 
         writer.from_pil(pil_image)


### PR DESCRIPTION
This swaps the H,W axis in the tiffwriter so they are compatible with the outputs of `SlideImage`