### PR TITLE
Allow simplification of polygons

### DIFF
--- a/dlup/experimental_annotations.py
+++ b/dlup/experimental_annotations.py
@@ -425,9 +425,8 @@ class WsiAnnotations:
         None
 
         """
-        self._annotations = {
-            k: v.simplify(tolerance, preserve_topology=preserve_topology) for k, v in self._annotations.items()
-        }
+        for k in self._annotations:
+            self._annotations[k].simplify(tolerance, preserve_topology=preserve_topology)
 
     def read_region(
         self,

--- a/dlup/experimental_annotations.py
+++ b/dlup/experimental_annotations.py
@@ -195,7 +195,7 @@ class WsiSingleLabelAnnotation:
         data = [np.asarray(annotation.envelope.exterior.coords) for annotation in self.as_list()]
         return [_get_bbox(_) for _ in data]
 
-    def simplify(self, tolerance: float, preserve_topology: bool = True):
+    def simplify(self, tolerance: float, *, preserve_topology: bool = True):
         if self.__type != AnnotationType.POLYGON:
             return
         self._annotations = [
@@ -409,7 +409,7 @@ class WsiAnnotations:
                 index += 1
         return data
 
-    def simplify(self, tolerance: float, preserve_topology: bool = True):
+    def simplify(self, tolerance: float, *, preserve_topology: bool = True):
         """Simplify the polygons in the annotation (i.e. reduce points). Other annotations will remain unchanged.
         All points in the resulting polygons object will be in the tolerance distance of the original polygon.
 

--- a/dlup/experimental_annotations.py
+++ b/dlup/experimental_annotations.py
@@ -195,6 +195,14 @@ class WsiSingleLabelAnnotation:
         data = [np.asarray(annotation.envelope.exterior.coords) for annotation in self.as_list()]
         return [_get_bbox(_) for _ in data]
 
+    def simplify(self, tolerance: float, preserve_topology: bool = True):
+        if self.__type != AnnotationType.POLYGON:
+            return
+        self._annotations = [
+            Polygon(annotation.simplify(tolerance, preserve_topology=preserve_topology), label=self.__label)
+            for annotation in self._annotations
+        ]
+
     def __len__(self) -> int:
         return len(self._annotations)
 
@@ -400,6 +408,26 @@ class WsiAnnotations:
                 data["features"].append(json_dict)
                 index += 1
         return data
+
+    def simplify(self, tolerance: float, preserve_topology: bool = True):
+        """Simplify the polygons in the annotation (i.e. reduce points). Other annotations will remain unchanged.
+        All points in the resulting polygons object will be in the tolerance distance of the original polygon.
+
+        Arguments
+        ---------
+        tolerance : float
+        preserve_topology : bool
+            Preserve the topology, if false, this function will be much faster. Internally the `shapely` simplify
+            algorithm is used.
+
+        Returns
+        -------
+        None
+
+        """
+        self._annotations = {
+            k: v.simplify(tolerance, preserve_topology=preserve_topology) for k, v in self._annotations.items()
+        }
 
     def read_region(
         self,


### PR DESCRIPTION
When polygons are generated from a mask they can sometimes contain a lot of points. The `.simplify()` call reduces this.