### PR TITLE
Transforms should only be applied on the used class

### DIFF
--- a/dlup/data/dataset.py
+++ b/dlup/data/dataset.py
@@ -330,9 +330,10 @@ class TiledROIsSlideImageDataset(SlideImageDatasetBase[RegionFromSlideDatasetSam
             mask_threshold=mask_threshold,
             annotations=annotations,
             labels=labels,
-            transform=transform,
+            transform=None,
             backend=backend,
         )
+        self.__transform = transform
 
     @property
     def grids(self):
@@ -437,6 +438,10 @@ class TiledROIsSlideImageDataset(SlideImageDatasetBase[RegionFromSlideDatasetSam
         grid_local_coordinates = np.unravel_index(grid_index, self.grids[starting_index][0].size)
         region_data["grid_local_coordinates"] = grid_local_coordinates
         region_data["grid_index"] = starting_index
+
+        if self.__transform:
+            region_data = self.__transform(region_data)
+
         return region_data
 
 

--- a/dlup/data/transforms.py
+++ b/dlup/data/transforms.py
@@ -214,5 +214,5 @@ class ContainsPolygonToLabel:
 
         label_area = shapely.geometry.MultiPolygon(requested_polygons).intersection(roi).area
         proportion = label_area / np.prod(sample["image"].size)
-        sample["labels"].update({f"has {self._label}": proportion >= self._threshold})
+        sample["labels"].update({f"has {self._label}": proportion > self._threshold})
         return sample


### PR DESCRIPTION
When transforms are set they should only be applied to the actual used Dataset class