### PR TITLE
Allow to overwrite mpp

### DIFF
--- a/dlup/_image.py
+++ b/dlup/_image.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import errno
 import os
 import pathlib
+import warnings
 from typing import Callable, Optional, Tuple, Type, TypeVar, Union
 
 import numpy as np  # type: ignore
@@ -88,8 +89,12 @@ class SlideImage:
         self._wsi = wsi
         self._identifier = identifier
 
-        check_if_mpp_is_valid(*self._wsi.spacing)
-        self._min_native_mpp = float(self._wsi.spacing[0])
+        if self._wsi.spacing:
+            check_if_mpp_is_valid(*self._wsi.spacing)
+            self._min_native_mpp = float(self._wsi.spacing[0])
+        else:
+            self._min_native_mpp = None
+            warnings.warn(f"{identifier} has an missing mpp value. Overwrite by setting the `.mpp` property.")
 
     def close(self):
         """Close the underlying image."""
@@ -287,6 +292,10 @@ class SlideImage:
     def mpp(self) -> float:
         """Returns the microns per pixel of the high res image."""
         return self._min_native_mpp
+
+    @mpp.setter
+    def mpp(self, value: float):
+        self._min_native_mpp = value
 
     @property
     def magnification(self) -> Optional[float]:

--- a/dlup/data/dataset.py
+++ b/dlup/data/dataset.py
@@ -353,6 +353,7 @@ class TiledROIsSlideImageDataset(SlideImageDatasetBase[RegionFromSlideDatasetSam
         labels: Optional[List[Tuple[str, _LabelTypes]]] = None,
         transform: Optional[Callable] = None,
         backend: Callable = ImageBackend.PYVIPS,
+        overwrite_mpp: Optional[float] = None,
     ):
         """Function to be used to tile a WSI on-the-fly.
         Parameters
@@ -385,6 +386,8 @@ class TiledROIsSlideImageDataset(SlideImageDatasetBase[RegionFromSlideDatasetSam
             Transform to be applied to the sample.
         backend :
             Backend to use to read the whole slide image.
+        overwrite_mpp : float
+            In case an mpp value is missing, this value is required to overwrite the mpp value
 
         Examples
         --------
@@ -397,6 +400,8 @@ class TiledROIsSlideImageDataset(SlideImageDatasetBase[RegionFromSlideDatasetSam
         pre-processing step is not required.
         """
         with SlideImage.from_file_path(path, backend=backend) as slide_image:
+            if overwrite_mpp:
+                slide_image.mpp = overwrite_mpp
             slide_level_size = slide_image.get_scaled_size(slide_image.get_scaling(mpp))
             slide_mpp = slide_image.mpp
             _rois = parse_rois(rois, slide_level_size, scaling=slide_mpp / mpp if mpp else 1.0)

--- a/dlup/experimental_backends/common.py
+++ b/dlup/experimental_backends/common.py
@@ -52,7 +52,7 @@ class AbstractSlideBackend(abc.ABC):
         self._filename = filename
         self._level_count = 0
         self._downsamples: List[float] = []
-        self._spacings: List[Tuple[Any, ...]] = []  # This is to make mypy shut up
+        self._spacings: Optional[List[Tuple[Any, ...]]] = []  # This is to make mypy shut up
         self._shapes: List[Tuple[int, int]] = []
 
     @property
@@ -83,7 +83,7 @@ class AbstractSlideBackend(abc.ABC):
         return self.level_dimensions[0]
 
     @property
-    def spacing(self) -> Tuple[Any, ...]:
+    def spacing(self) -> Optional[Tuple[Any, ...]]:
         """
         A (mpp_x, mpp_y) tuple for spacing of the base level
 
@@ -91,6 +91,8 @@ class AbstractSlideBackend(abc.ABC):
         -------
         Tuple
         """
+        if not self._spacings:
+            return None
         return self._spacings[0]
 
     @property

--- a/dlup/experimental_backends/pyvips_backend.py
+++ b/dlup/experimental_backends/pyvips_backend.py
@@ -108,11 +108,14 @@ class PyVipsSlide(AbstractSlideBackend):
         for idx, image in enumerate(self._images):
             self._downsamples.append(float(image.get(f"openslide.level[{idx}].downsample")))
 
-        mpp_x = float(self._images[0].get("openslide.mpp-x"))
-        mpp_y = float(self._images[0].get("openslide.mpp-y"))
-        check_if_mpp_is_valid(mpp_x, mpp_y)
-
-        self._spacings = [(np.array([mpp_y, mpp_x]) * downsample).tolist() for downsample in self._downsamples]
+        try:
+            mpp_x = float(self._images[0].get("openslide.mpp-x"))
+            mpp_y = float(self._images[0].get("openslide.mpp-y"))
+            check_if_mpp_is_valid(mpp_x, mpp_y)
+            self._spacings = [(np.array([mpp_y, mpp_x]) * downsample).tolist() for downsample in self._downsamples]
+        except pyvips.Error:
+            # The mpp value cannot be parsed
+            self._spacings = None
 
     @property
     def properties(self):


### PR DESCRIPTION
If mpp values are not available in the slide, the code would crash. A parameter to overwrite mpp values has been implemented.