### PR TITLE
Update shapely

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -22,7 +22,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         pip install coverage
-        pip install git+https://github.com/shapely/shapely
         pip install -e ".[dev]"
     - name: Run Coverage
       run: |

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -22,7 +22,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install mypy
-        python -m pip install git+https://github.com/shapely/shapely
         python -m pip install -e ".[dev]"
     - name: mypy
       run: |

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -20,7 +20,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install git+https://github.com/shapely/shapely
         pip install pylint
         pip install -e .
     - name: Analysing the code with pylint

--- a/README.md
+++ b/README.md
@@ -15,5 +15,4 @@ Check the [full documentation](https://docs.aiforoncology.nl/dlup) for more deta
 - Annotation classes which can load GeoJSON and ASAP formats and convert these to masks.
 
 ### Quickstart
-The package can be installed using `pip install dlup`. However, that requires the installation of the beta (upstream)
-version of [shapely](https://github.com/shapely/shapely) using `pip install git+https://github.com/shapely/shapely.git`.
+The package can be installed using `pip install dlup`.

--- a/dlup/__init__.py
+++ b/dlup/__init__.py
@@ -8,6 +8,6 @@ from ._region import BoundaryMode, RegionView
 
 __author__ = """dlup contributors"""
 __email__ = "j.teuwen@nki.nl"
-__version__ = "0.3.10-dev0"
+__version__ = "0.3.10"
 
 __all__ = ("SlideImage", "RegionView", "UnsupportedSlideError", "BoundaryMode")

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -20,13 +20,6 @@ install all other required packages.
     See `this GitHub issue`_ for details. This version is automatically compiled in
     the `dlup Dockerfile`_.
 
-.. warning::
-    `shapely`_ version 2.0 or higher is required for dlup to work correctly.
-    This needs to be installed from the development branch of shapely as follows
-    .. code-block:: console
-
-        pip install git+https://github.com/shapely/shapely
-
 
 Build from Source
 -----------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.10-dev0
+current_version = 0.3.10
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,6 @@
 """The setup script."""
 
 import ast
-import os
-from typing import List
 
 from setuptools import find_packages, setup  # type: ignore
 
@@ -30,13 +28,8 @@ install_requires = [
     "pillow>=9.2.0",
     "openslide-python",
     "opencv-python>=4.6.0",
+    "shapely>=2.0b2",
 ]
-
-# This is a hack as PyPi does not want package installed from github, but tox will fail and we are using
-# the upstream version of shapely
-if os.environ.get("IS_TOX", False):
-    install_requires.append("shapely @ git+https://github.com/shapely/shapely.git")
-
 
 setup(
     author="Jonas Teuwen",


### PR DESCRIPTION
Current dlup uses the github version of shapely, as it requires features of shapely 2.0 and higher. This is now replaced by the 2.0 beta version available on pypi.