### PR TITLE
Allow mpp to differ by 1.5%

### DIFF
--- a/dlup/__init__.py
+++ b/dlup/__init__.py
@@ -8,6 +8,6 @@ from ._region import BoundaryMode, RegionView
 
 __author__ = """dlup contributors"""
 __email__ = "j.teuwen@nki.nl"
-__version__ = "0.3.11"
+__version__ = "0.3.12-dev0"
 
 __all__ = ("SlideImage", "RegionView", "UnsupportedSlideError", "BoundaryMode")

--- a/dlup/__init__.py
+++ b/dlup/__init__.py
@@ -8,6 +8,6 @@ from ._region import BoundaryMode, RegionView
 
 __author__ = """dlup contributors"""
 __email__ = "j.teuwen@nki.nl"
-__version__ = "0.3.12-dev0"
+__version__ = "0.3.12"
 
 __all__ = ("SlideImage", "RegionView", "UnsupportedSlideError", "BoundaryMode")

--- a/dlup/_image.py
+++ b/dlup/_image.py
@@ -20,11 +20,10 @@ import PIL
 import PIL.Image  # type: ignore
 
 from dlup import UnsupportedSlideError
+from dlup._region import BoundaryMode, RegionView
 from dlup.experimental_backends import AbstractSlideBackend, ImageBackend
 from dlup.types import GenericFloatArray, GenericIntArray, GenericNumber, PathLike
-
-from ._region import BoundaryMode, RegionView
-from .utils.image import check_if_mpp_is_valid
+from dlup.utils.image import check_if_mpp_is_valid
 
 _Box = Tuple[GenericNumber, GenericNumber, GenericNumber, GenericNumber]
 _TSlideImage = TypeVar("_TSlideImage", bound="SlideImage")
@@ -89,7 +88,7 @@ class SlideImage:
         self._identifier = identifier
 
         check_if_mpp_is_valid(*self._wsi.spacing)
-        self._min_native_mpp = float(self._wsi.spacing[0])
+        self._avg_native_mpp = (float(self._wsi.spacing[0]) + float(self._wsi.spacing[1])) / 2
 
     def close(self):
         """Close the underlying image."""
@@ -236,13 +235,13 @@ class SlideImage:
 
     def get_mpp(self, scaling: float) -> float:
         """Returns the respective mpp from the scaling."""
-        return self._min_native_mpp / scaling
+        return self._avg_native_mpp / scaling
 
     def get_scaling(self, mpp: float | None) -> float:
         """Inverse of get_mpp()."""
         if not mpp:
             return 1.0
-        return self._min_native_mpp / mpp
+        return self._avg_native_mpp / mpp
 
     def get_scaled_view(self, scaling: GenericNumber) -> _SlideImageRegionView:
         """Returns a RegionView at a specific level."""
@@ -286,7 +285,7 @@ class SlideImage:
     @property
     def mpp(self) -> float:
         """Returns the microns per pixel of the high res image."""
-        return self._min_native_mpp
+        return self._avg_native_mpp
 
     @property
     def magnification(self) -> Optional[float]:

--- a/dlup/utils/image.py
+++ b/dlup/utils/image.py
@@ -1,16 +1,18 @@
-import numpy as np
+import math
 
 from dlup import UnsupportedSlideError
 
 
-def check_if_mpp_is_valid(mpp_x: float, mpp_y: float) -> None:
+def check_if_mpp_is_valid(mpp_x: float, mpp_y: float, rel_tol: float = 0.015) -> None:
     """
-    Checks if the mpp is (nearly) isotropic and defined.
+    Checks if the mpp is (nearly) isotropic and defined. The maximum allowed rel_tol
 
     Parameters
     ----------
     mpp_x : float
     mpp_y : float
+    rel_tol : float
+        Relative tolerance between mpp_x and mpp_y. 1.5% seems to work well for most slides.
 
     Returns
     -------
@@ -19,5 +21,5 @@ def check_if_mpp_is_valid(mpp_x: float, mpp_y: float) -> None:
     if mpp_x == 0 or mpp_y == 0:
         raise UnsupportedSlideError(f"Unable to parse mpp.")
 
-    if not mpp_x or not mpp_y or not np.isclose(mpp_x, mpp_y, rtol=1.0e-2):
+    if not mpp_x or not mpp_y or not math.isclose(mpp_x, mpp_y, rel_tol=rel_tol):
         raise UnsupportedSlideError(f"cannot deal with slides having anisotropic mpps. Got {mpp_x} and {mpp_y}.")

--- a/dlup/utils/image.py
+++ b/dlup/utils/image.py
@@ -3,7 +3,7 @@ import math
 from dlup import UnsupportedSlideError
 
 
-def check_if_mpp_is_valid(mpp_x: float, mpp_y: float, rel_tol: float = 0.015) -> None:
+def check_if_mpp_is_valid(mpp_x: float, mpp_y: float, *, rel_tol: float = 0.015) -> None:
     """
     Checks if the mpp is (nearly) isotropic and defined. The maximum allowed rel_tol
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.12-dev0
+current_version = 0.3.12
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.11
+current_version = 0.3.12-dev0
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?


### PR DESCRIPTION
Some images with a (minor) difference in mpp-x and mpp-y cannot be read. This PR:
- checks if these values are within 1.5%
- replaces min(mpp) with avg(mpp) as the value used for rescaling