### PR TITLE
Allow to overwrite mpp

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
     steps:
     - name: Install minimal dependencies
       run: |

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -14,10 +14,10 @@ jobs:
         run: |
             sudo apt install -y libgeos-dev
     - uses: actions/checkout@v1
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -13,10 +13,10 @@ jobs:
       run: |
         sudo apt install -y libopenslide0 libgeos-dev
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -13,10 +13,10 @@ jobs:
       run: |
         sudo apt install -y libopenslide0 libgeos-dev
     - uses: actions/checkout@v2
-    - name: Set up Python 3.10
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.9, 3.10]
 
     steps:
     - name: Install minimal dependencies

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.10]
+        python-version: ["3.9", "3.10"]
 
     steps:
     - name: Install minimal dependencies

--- a/dlup/_image.py
+++ b/dlup/_image.py
@@ -82,10 +82,13 @@ class SlideImage:
     >>> wsi = dlup.SlideImage.from_file_path('path/to/slide.svs')
     """
 
-    def __init__(self, wsi: AbstractSlideBackend, identifier: Union[str, None] = None):
+    def __init__(self, wsi: AbstractSlideBackend, identifier: Union[str, None] = None, **kwargs):
         """Initialize a whole slide image and validate its properties."""
         self._wsi = wsi
         self._identifier = identifier
+
+        if "overwrite_mpp" in kwargs:
+            self._wsi.spacing = kwargs["overwrite_mpp"]
 
         check_if_mpp_is_valid(*self._wsi.spacing)
         self._avg_native_mpp = (float(self._wsi.spacing[0]) + float(self._wsi.spacing[1])) / 2
@@ -107,6 +110,7 @@ class SlideImage:
         wsi_file_path: PathLike,
         identifier: Union[str, None] = None,
         backend: Union[str, Callable] = ImageBackend.PYVIPS,
+        **kwargs,
     ) -> _TSlideImage:
         wsi_file_path = pathlib.Path(wsi_file_path)
 
@@ -120,7 +124,7 @@ class SlideImage:
         except UnsupportedSlideError:
             raise UnsupportedSlideError(f"Unsupported file: {wsi_file_path}")
 
-        return cls(wsi, str(wsi_file_path) if identifier is None else identifier)
+        return cls(wsi, str(wsi_file_path) if identifier is None else identifier, **kwargs)
 
     # @image_cache
     def read_region(

--- a/dlup/_image.py
+++ b/dlup/_image.py
@@ -92,7 +92,7 @@ class SlideImage:
 
         if self._wsi.spacing is None:
             raise UnsupportedSlideError(
-                f"{identifier} has not parsable spacing and not explicitly set in the `overwrite_mpp` parameter."
+                f"The spacing of {identifier} cannot be derived from image and is not explicitly set in the `overwrite_mpp` parameter."
             )
 
         check_if_mpp_is_valid(*self._wsi.spacing)

--- a/dlup/_image.py
+++ b/dlup/_image.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import errno
 import os
 import pathlib
-from typing import Callable, Optional, Tuple, Type, TypeVar, Union
+from typing import Callable, Optional, Tuple, Type, TypeVar, Union, cast
 
 import numpy as np  # type: ignore
 import openslide  # type: ignore
@@ -49,7 +49,7 @@ class _SlideImageRegionView(RegionView):
         """Size"""
         return self._wsi.get_scaled_size(self._scaling)
 
-    def _read_region_impl(self, location: GenericFloatArray, size: GenericIntArray) -> PIL.Image:
+    def _read_region_impl(self, location: GenericFloatArray, size: GenericIntArray) -> PIL.Image.Image:
         """Returns a region of the level associated to the view."""
         x, y = location
         w, h = size
@@ -89,6 +89,11 @@ class SlideImage:
 
         if "overwrite_mpp" in kwargs:
             self._wsi.spacing = kwargs["overwrite_mpp"]
+
+        if self._wsi.spacing is None:
+            raise UnsupportedSlideError(
+                f"{identifier} has not parsable spacing and not explicitly set in the `overwrite_mpp` parameter."
+            )
 
         check_if_mpp_is_valid(*self._wsi.spacing)
         self._avg_native_mpp = (float(self._wsi.spacing[0]) + float(self._wsi.spacing[1])) / 2
@@ -132,7 +137,7 @@ class SlideImage:
         location: Union[np.ndarray, Tuple[GenericNumber, GenericNumber]],
         scaling: float,
         size: Union[np.ndarray, Tuple[int, int]],
-    ) -> PIL.Image:
+    ) -> PIL.Image.Image:
         """Return a region at a specific scaling level of the pyramid.
 
         A typical slide is made of several levels at different mpps.
@@ -235,6 +240,8 @@ class SlideImage:
             *fractional_coordinates,
             *np.clip((fractional_coordinates + native_size), a_min=0, a_max=np.asarray(region.size)),
         )
+        box = cast(tuple[float, float, float, float], box)
+        size = cast(tuple[int, int], size)
         return region.resize(size, resample=PIL.Image.Resampling.LANCZOS, box=box)
 
     def get_scaled_size(self, scaling: GenericNumber) -> Tuple[int, ...]:
@@ -256,7 +263,7 @@ class SlideImage:
         """Returns a RegionView at a specific level."""
         return _SlideImageRegionView(self, scaling)
 
-    def get_thumbnail(self, size: Tuple[int, int] = (512, 512)) -> PIL.Image:
+    def get_thumbnail(self, size: Tuple[int, int] = (512, 512)) -> PIL.Image.Image:
         """Returns an RGB numpy thumbnail for the current slide.
 
         Parameters
@@ -267,7 +274,7 @@ class SlideImage:
         return self._wsi.get_thumbnail(size)
 
     @property
-    def thumbnail(self) -> PIL.Image:
+    def thumbnail(self) -> PIL.Image.Image:
         """Returns the thumbnail."""
         return self.get_thumbnail()
 

--- a/dlup/_region.py
+++ b/dlup/_region.py
@@ -2,7 +2,7 @@
 """Defines the RegionView interface."""
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Iterable, Optional, Tuple, Union
+from typing import Iterable, Optional, Tuple, Union, cast
 
 import numpy as np
 import PIL.Image
@@ -40,7 +40,7 @@ class RegionView(ABC):
         """Returns size of the region in U units."""
         pass
 
-    def read_region(self, location: _GenericFloatArray, size: _GenericIntArray) -> PIL.Image:
+    def read_region(self, location: _GenericFloatArray, size: _GenericIntArray) -> PIL.Image.Image:
         """Returns the requested region as a numpy array."""
         location = np.asarray(location)
         size = np.asarray(size)
@@ -60,15 +60,17 @@ class RegionView(ABC):
 
         if self.boundary_mode == BoundaryMode.zero:
             if np.any(size != clipped_region_size) or np.any(location < 0):
-                new_region = PIL.Image.new(str(region.mode), tuple(size))
+                size = cast(tuple[int, int], size)
+                new_region = PIL.Image.new(str(region.mode), size)
                 # Now we need to paste the region into the new region.
                 # We do some rounding to int.
-                new_region.paste(region, tuple(np.floor(offset).astype(int)))
+                coordinates = cast(tuple[int, int], tuple(np.floor(offset).astype(int)))
+                new_region.paste(region, coordinates)
                 return new_region
 
         return region
 
     @abstractmethod
-    def _read_region_impl(self, location: _GenericFloatArray, size: _GenericIntArray) -> PIL.Image:
+    def _read_region_impl(self, location: _GenericFloatArray, size: _GenericIntArray) -> PIL.Image.Image:
         """Define a method to return an array containing the region."""
         pass

--- a/dlup/background.py
+++ b/dlup/background.py
@@ -286,11 +286,11 @@ def is_foreground_numpy(
     mask_size = np.array(background_mask.shape[:2][::-1])
 
     region_view = slide_image.get_scaled_view(slide_image.get_scaling(mpp))
-    background_mask = PIL.Image.fromarray(background_mask)
+    _background_mask = PIL.Image.fromarray(background_mask)
 
     # Type of background_mask is Any here.
     # The scaling should be computed using the longest edge of the image.
-    background_size = (background_mask.width, background_mask.height)  # type: ignore
+    background_size = (_background_mask.width, _background_mask.height)  # type: ignore
 
     region_size = region_view.size
     max_dimension_index = max(range(len(background_size)), key=background_size.__getitem__)
@@ -309,7 +309,7 @@ def is_foreground_numpy(
         return False
 
     mask_tile[:clipped_h, :clipped_w] = np.asarray(
-        background_mask.resize((clipped_w, clipped_h), PIL.Image.BICUBIC, box=box), dtype=float  # type: ignore
+        _background_mask.resize((clipped_w, clipped_h), PIL.Image.BICUBIC, box=box), dtype=float  # type: ignore
     )
     return mask_tile.mean() >= threshold
 

--- a/dlup/data/dataset.py
+++ b/dlup/data/dataset.py
@@ -370,6 +370,7 @@ class TiledROIsSlideImageDataset(SlideImageDatasetBase[RegionFromSlideDatasetSam
         labels: Optional[List[Tuple[str, _LabelTypes]]] = None,
         transform: Optional[Callable] = None,
         backend: Callable = ImageBackend.PYVIPS,
+        **kwargs,
     ):
         """Function to be used to tile a WSI on-the-fly.
         Parameters
@@ -405,6 +406,8 @@ class TiledROIsSlideImageDataset(SlideImageDatasetBase[RegionFromSlideDatasetSam
             Transform to be applied to the sample.
         backend :
             Backend to use to read the whole slide image.
+        **kwargs :
+            Gets passed to the SlideImage constructor.
 
         Examples
         --------
@@ -416,7 +419,7 @@ class TiledROIsSlideImageDataset(SlideImageDatasetBase[RegionFromSlideDatasetSam
         Calling this dataset with an index will return a tile extracted straight from the WSI. This means tiling as
         pre-processing step is not required.
         """
-        with SlideImage.from_file_path(path, backend=backend) as slide_image:
+        with SlideImage.from_file_path(path, backend=backend, **kwargs) as slide_image:
             slide_level_size = slide_image.get_scaled_size(slide_image.get_scaling(mpp))
             slide_mpp = slide_image.mpp
             _rois = parse_rois(rois, slide_level_size, scaling=slide_mpp / mpp if mpp else 1.0)

--- a/dlup/experimental_backends/common.py
+++ b/dlup/experimental_backends/common.py
@@ -1,5 +1,7 @@
 # coding=utf-8
 # Copyright (c) dlup contributors
+from __future__ import annotations
+
 import abc
 from typing import Any, List, Optional, Tuple, Union
 
@@ -9,7 +11,7 @@ import PIL.Image
 from dlup.types import PathLike
 
 
-def numpy_to_pil(tile: np.ndarray) -> PIL.Image:
+def numpy_to_pil(tile: np.ndarray) -> PIL.Image.Image:
     """
     Convert a numpy tile to a PIL image, assuming the last axis is the channels
 
@@ -51,9 +53,9 @@ class AbstractSlideBackend(abc.ABC):
         """
         self._filename = filename
         self._level_count = 0
-        self._downsamples: List[float] = []
-        self._spacings: List[Tuple[Any, ...]] = []  # This is to make mypy shut up
-        self._shapes: List[Tuple[int, int]] = []
+        self._downsamples: list[float] = []
+        self._spacings: list[tuple[float, float]] = []
+        self._shapes: list[tuple[int, int]] = []
 
     @property
     def level_count(self) -> int:
@@ -61,7 +63,7 @@ class AbstractSlideBackend(abc.ABC):
         return self._level_count
 
     @property
-    def level_dimensions(self) -> List[Tuple[int, int]]:
+    def level_dimensions(self) -> list[tuple[int, int]]:
         """A list of (width, height) tuples, one for each level of the image.
         This property level_dimensions[n] contains the dimensions of the image at level n.
 
@@ -73,7 +75,7 @@ class AbstractSlideBackend(abc.ABC):
         return self._shapes
 
     @property
-    def dimensions(self) -> Tuple[int, int]:
+    def dimensions(self) -> tuple[int, int]:
         """A (width, height) tuple for the base level (level 0) of the image.
 
         Returns
@@ -83,7 +85,7 @@ class AbstractSlideBackend(abc.ABC):
         return self.level_dimensions[0]
 
     @property
-    def spacing(self) -> Tuple[Any, ...]:
+    def spacing(self) -> tuple[float, float] | None:
         """
         A (mpp_x, mpp_y) tuple for spacing of the base level
 
@@ -91,10 +93,16 @@ class AbstractSlideBackend(abc.ABC):
         -------
         Tuple
         """
-        return self._spacings[0]
+        if self._spacings is not None:
+            return self._spacings[0]
+        return
+
+    @spacing.setter
+    def spacing(self, value: tuple[float, float]) -> None:
+        """Set the spacing as a (mpp_x, mpp_y) tuple"""
 
     @property
-    def level_spacings(self) -> Tuple[Tuple[Any, ...], ...]:
+    def level_spacings(self) -> tuple[tuple[float, float], ...]:
         """
         A list of (mpp_x, mpp_y) tuples, one for each level of the image.
         This property level_spacings[n] contains the spacings of the image at level n.
@@ -107,7 +115,7 @@ class AbstractSlideBackend(abc.ABC):
         return tuple(self._spacings)
 
     @property
-    def level_downsamples(self) -> Tuple[float, ...]:
+    def level_downsamples(self) -> tuple[float, ...]:
         """A tuple of downsampling factors for each level of the image.
         level_downsample[n] contains the downsample factor of level n."""
         return tuple(self._downsamples)
@@ -132,7 +140,7 @@ class AbstractSlideBackend(abc.ABC):
         number = max(sorted_downsamples, key=difference)
         return self._downsamples.index(number)
 
-    def get_thumbnail(self, size: Union[int, Tuple[int, int]]) -> PIL.Image:
+    def get_thumbnail(self, size: Union[int, Tuple[int, int]]) -> PIL.Image.Image:
         """
         Return a PIL.Image as an RGB image with the thumbnail with maximum size given by size.
         Aspect ratio is preserved.
@@ -168,7 +176,7 @@ class AbstractSlideBackend(abc.ABC):
         """Properties of slide"""
 
     @abc.abstractmethod
-    def read_region(self, coordinates: Tuple[Any, ...], level: int, size: Tuple[Any, ...]) -> PIL.Image:
+    def read_region(self, coordinates: Tuple[Any, ...], level: int, size: Tuple[Any, ...]) -> PIL.Image.Image:
         """
         Return the best level for displaying the given image level.
 

--- a/dlup/experimental_backends/openslide_backend.py
+++ b/dlup/experimental_backends/openslide_backend.py
@@ -64,7 +64,7 @@ class OpenSlideSlide(openslide.OpenSlide, AbstractSlideBackend):
         self._spacings = [cast(tuple[float, float], tuple(mpp * downsample)) for downsample in self.level_downsamples]
 
     @property
-    def magnification(self) -> float | None:
+    def magnification(self) -> int | None:
         """Returns the objective power at which the WSI was sampled."""
         value = self.properties.get(openslide.PROPERTY_NAME_OBJECTIVE_POWER, None)
         if value is not None:

--- a/dlup/experimental_backends/openslide_backend.py
+++ b/dlup/experimental_backends/openslide_backend.py
@@ -2,7 +2,7 @@
 # Copyright (c) dlup contributors
 from __future__ import annotations
 
-from typing import Any, Tuple, Union
+from typing import Tuple, Union, cast
 
 import numpy as np
 import openslide
@@ -48,23 +48,23 @@ class OpenSlideSlide(openslide.OpenSlide, AbstractSlideBackend):
             pass
 
     @property
-    def spacing(self) -> Tuple[Any, ...] | None:
+    def spacing(self) -> tuple[float, float] | None:
         if not self._spacings:
             return None
         return self._spacings[0]
 
     @spacing.setter
-    def spacing(self, value: Tuple[Any, ...]) -> None:
+    def spacing(self, value: tuple[float, float]) -> None:
         if not isinstance(value, tuple) and len(value) != 2:
             raise ValueError(f"`.spacing` has to be of the form (mpp_x, mpp_y).")
 
         mpp_x, mpp_y = value
         check_if_mpp_is_valid(mpp_x, mpp_y)
         mpp = np.array([mpp_y, mpp_x])
-        self._spacings = [tuple(mpp * downsample) for downsample in self.level_downsamples]
+        self._spacings = [cast(tuple[float, float], tuple(mpp * downsample)) for downsample in self.level_downsamples]
 
     @property
-    def magnification(self) -> float:
+    def magnification(self) -> float | None:
         """Returns the objective power at which the WSI was sampled."""
         value = self.properties.get(openslide.PROPERTY_NAME_OBJECTIVE_POWER, None)
         if value is not None:
@@ -76,7 +76,7 @@ class OpenSlideSlide(openslide.OpenSlide, AbstractSlideBackend):
         """Returns the scanner vendor."""
         return self.properties.properties[openslide.PROPERTY_NAME_VENDOR]
 
-    def get_thumbnail(self, size: Union[int, Tuple[int, int]]) -> PIL.Image:
+    def get_thumbnail(self, size: Union[int, Tuple[int, int]]) -> PIL.Image.Image:
         """
         Return a PIL.Image as an RGB image with the thumbnail with maximum size given by size.
         Aspect ratio is preserved.

--- a/dlup/experimental_backends/openslide_backend.py
+++ b/dlup/experimental_backends/openslide_backend.py
@@ -1,15 +1,16 @@
 # coding=utf-8
 # Copyright (c) dlup contributors
 from __future__ import annotations
-from typing import Tuple, Union, Any
+
+from typing import Any, Tuple, Union
 
 import numpy as np
 import openslide
 import PIL.Image
-from dlup.utils.image import check_if_mpp_is_valid
 
 from dlup.experimental_backends.common import AbstractSlideBackend
 from dlup.types import PathLike
+from dlup.utils.image import check_if_mpp_is_valid
 
 
 def open_slide(filename: PathLike) -> "OpenSlideSlide":
@@ -45,6 +46,7 @@ class OpenSlideSlide(openslide.OpenSlide, AbstractSlideBackend):
 
         except KeyError:
             pass
+
     @property
     def spacing(self) -> Tuple[Any, ...] | None:
         if not self._spacings:

--- a/dlup/experimental_backends/pyvips_backend.py
+++ b/dlup/experimental_backends/pyvips_backend.py
@@ -126,13 +126,13 @@ class PyVipsSlide(AbstractSlideBackend):
             )
 
     @property
-    def spacing(self) -> Tuple[Any, ...] | None:
+    def spacing(self) -> tuple[float, float] | None:
         if not self._spacings:
             return None
         return self._spacings[0]
 
     @spacing.setter
-    def spacing(self, value: Tuple[Any, ...]) -> None:
+    def spacing(self, value: tuple[float, float]) -> None:
         if not isinstance(value, tuple) and len(value) != 2:
             raise ValueError(f"`.spacing` has to be of the form (mpp_x, mpp_y).")
 
@@ -174,7 +174,7 @@ class PyVipsSlide(AbstractSlideBackend):
     def set_cache(self, cache):
         raise NotImplementedError
 
-    def read_region(self, coordinates: Tuple[Any, ...], level: int, size: Tuple[Any, ...]) -> PIL.Image:
+    def read_region(self, coordinates: Tuple[Any, ...], level: int, size: Tuple[Any, ...]) -> PIL.Image.Image:
         """
         Return the best level for displaying the given image level.
 

--- a/dlup/experimental_backends/pyvips_backend.py
+++ b/dlup/experimental_backends/pyvips_backend.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 # Copyright (c) dlup contributors
+from __future__ import annotations
 from typing import Any, Optional, Tuple
 
 import numpy as np
@@ -11,7 +12,7 @@ from dlup import UnsupportedSlideError
 from dlup.experimental_backends.common import AbstractSlideBackend, numpy_to_pil
 from dlup.types import PathLike
 from dlup.utils.image import check_if_mpp_is_valid
-
+import warnings
 
 def open_slide(filename: PathLike) -> "PyVipsSlide":
     """
@@ -108,10 +109,31 @@ class PyVipsSlide(AbstractSlideBackend):
         for idx, image in enumerate(self._images):
             self._downsamples.append(float(image.get(f"openslide.level[{idx}].downsample")))
 
-        mpp_x = float(self._images[0].get("openslide.mpp-x"))
-        mpp_y = float(self._images[0].get("openslide.mpp-y"))
-        check_if_mpp_is_valid(mpp_x, mpp_y)
+        mpp_x, mpp_y = None, None
+        available_fields = self._images[0].get_fields()
+        if "openslide.mpp-x" in available_fields and "openslide.mpp-y" in available_fields:
+            mpp_x = self._images[0].get("openslide.mpp-x")
+            mpp_y = self._images[0].get("openslide.mpp-y")
 
+        if mpp_x is not None and mpp_y is not None:
+            check_if_mpp_is_valid(mpp_x, mpp_y)
+            self._spacings = [(np.array([mpp_y, mpp_x]) * downsample).tolist() for downsample in self._downsamples]
+        else:
+            warnings.warn(f"{path} does not have a parseable spacings property. You can overwrite it with `.mpp = (mpp_x, mpp_y).")
+
+    @property
+    def spacing(self) -> Tuple[Any, ...] | None:
+        if not self._spacings:
+            return None
+        return self._spacings[0]
+
+    @spacing.setter
+    def spacing(self, value: Tuple[Any, ...]) -> None:
+        if not isinstance(value, tuple) and len(value) != 2:
+            raise ValueError(f"`.spacing` has to be of the form (mpp_x, mpp_y).")
+
+        mpp_x, mpp_y = value
+        check_if_mpp_is_valid(mpp_x, mpp_y)
         self._spacings = [(np.array([mpp_y, mpp_x]) * downsample).tolist() for downsample in self._downsamples]
 
     @property

--- a/dlup/experimental_backends/pyvips_backend.py
+++ b/dlup/experimental_backends/pyvips_backend.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 # Copyright (c) dlup contributors
 from __future__ import annotations
+
+import warnings
 from typing import Any, Optional, Tuple
 
 import numpy as np
@@ -12,7 +14,7 @@ from dlup import UnsupportedSlideError
 from dlup.experimental_backends.common import AbstractSlideBackend, numpy_to_pil
 from dlup.types import PathLike
 from dlup.utils.image import check_if_mpp_is_valid
-import warnings
+
 
 def open_slide(filename: PathLike) -> "PyVipsSlide":
     """
@@ -119,7 +121,9 @@ class PyVipsSlide(AbstractSlideBackend):
             check_if_mpp_is_valid(mpp_x, mpp_y)
             self._spacings = [(np.array([mpp_y, mpp_x]) * downsample).tolist() for downsample in self._downsamples]
         else:
-            warnings.warn(f"{path} does not have a parseable spacings property. You can overwrite it with `.mpp = (mpp_x, mpp_y).")
+            warnings.warn(
+                f"{path} does not have a parseable spacings property. You can overwrite it with `.mpp = (mpp_x, mpp_y)."
+            )
 
     @property
     def spacing(self) -> Tuple[Any, ...] | None:

--- a/dlup/experimental_backends/tifffile_backend.py
+++ b/dlup/experimental_backends/tifffile_backend.py
@@ -88,7 +88,7 @@ class TifffileSlide(AbstractSlideBackend):
         """Cache for tifffile."""
         raise NotImplementedError
 
-    def read_region(self, coordinates: Tuple[Any, ...], level: int, size: Tuple[Any, ...]) -> PIL.Image:
+    def read_region(self, coordinates: Tuple[Any, ...], level: int, size: Tuple[Any, ...]) -> PIL.Image.Image:
         """
         Return the best level for displaying the given image level.
 

--- a/dlup/viz/plotting.py
+++ b/dlup/viz/plotting.py
@@ -1,5 +1,7 @@
 # coding=utf-8
 # Copyright (c) dlup Contributors
+from typing import Optional
+
 import numpy as np
 import PIL
 import PIL.Image
@@ -7,17 +9,16 @@ import PIL.ImageColor
 import PIL.ImageDraw
 
 from dlup.annotations import Point, Polygon
-from typing import Optional
 
 
 def plot_2d(
-    image: PIL.Image,
+    image: PIL.Image.Image,
     mask: Optional[np.ndarray] = None,
     mask_colors=None,
     mask_alpha=70,
     geometries=None,
     geometries_color_map=None,
-) -> PIL.Image:
+) -> PIL.Image.Image:
     """
     Plotting utility to overlay masks and geometries (Points, Polygons) on top of the image.
 

--- a/dlup/writers.py
+++ b/dlup/writers.py
@@ -103,7 +103,7 @@ class TifffileImageWriter(ImageWriter):
         self._pyramid = pyramid
         self._quality = quality
 
-    def from_pil(self, pil_image: PIL.Image) -> None:
+    def from_pil(self, pil_image: PIL.Image.Image) -> None:
         """
         Create tiff image from a PIL image
 
@@ -209,7 +209,7 @@ class TifffileImageWriter(ImageWriter):
         )
 
 
-def _tiles_iterator_from_pil_image(pil_image: PIL.Image, tile_size: Tuple[int, int]):
+def _tiles_iterator_from_pil_image(pil_image: PIL.Image.Image, tile_size: Tuple[int, int]):
     """
     Given a PIL image return a a tile-iterator.
 


### PR DESCRIPTION
- `overwrite_mpp=(mpp_x, mpp_y)` can now be added to the `SlideImage` and the `TiledROISlideImageDataset` constructors.