### PR TITLE
Added imagecodecs as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ install_requires = [
     "numpy>=1.21",
     "scikit-image>=0.19",
     "tifftools",
+    "imagecodecs",
     "tifffile>=2022.5.4",
     "pyvips>=2.2.1",
     "tqdm",


### PR DESCRIPTION
Currently installing dlup independently breaks because imagecodecs is not listed as a dependency but we need it for jpeg compression while reading/writing tiff files.
