### PR TITLE
Entropy masker

### DIFF
--- a/dlup/background.py
+++ b/dlup/background.py
@@ -175,6 +175,7 @@ def fesi(image: np.ndarray) -> np.ndarray:
     gray = np.abs(skimage.filters.laplace(gray, ksize=3))
     return _fesi_common(gray)
 
+
 def entropy_masker(
     image: np.ndarray,
     footprint: Union[np.ndarray, None] = None,
@@ -194,12 +195,12 @@ def entropy_masker(
         Number of bins for the entropy histogram.
     threshold_bounds : tuple[int, int], default=(1, 4)
         Lower and upper threshold for the binned entropy minimum.
-    
+
     Returns
     -------
     np.ndarray
         Tissue mask
-    
+
     References
     ----------
     .. [1] https://doi.org/10.1038/s41598-023-29638-1
@@ -226,8 +227,9 @@ def entropy_masker(
         # If no threshold threshold was within bounds,
         # return full image.
         mask = np.ones_like(gray, dtype=np.bool_)
-    
+
     return mask
+
 
 def next_power_of_2(x):
     """Returns the smallest greater than x, power of 2 value.

--- a/dlup/background.py
+++ b/dlup/background.py
@@ -207,7 +207,7 @@ def entropy_masker(
     gray = skimage.color.rgb2gray(image)
 
     if footprint is None:
-        footprint = skimage.morphology.disk(3)
+        footprint = skimage.morphology.disk(5)
 
     # Tissue has structural information that background does not have.
     # The entropy in tissue is assumed to be bigger.

--- a/dlup/background.py
+++ b/dlup/background.py
@@ -188,7 +188,7 @@ def entropy_masker(
     ----------
     image : np.ndarray
         2D RGB image, with color channels at the last axis.
-    footprint : np.ndarray, default=`skimage.morphology.disk(3)`
+    footprint : np.ndarray, default=`skimage.morphology.disk(5)`
         Footprint to use with `skimage.filters.rank.entropy`.
     bins : int
         Number of bins for the entropy histogram.

--- a/dlup/background.py
+++ b/dlup/background.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from enum import Enum
 from functools import partial
-from typing import Callable, Iterable, Union
+from typing import Callable, Iterable, Union, Any
 
 import numpy as np
 import numpy.typing as npt
@@ -181,7 +181,7 @@ def _connected_components(
     image: npt.NDArray,
     connectivity: Union[int, None] = None,
     num_largest_components: Union[int, None] = None,
-) -> np.ndarray[bool]:
+) -> np.ndarray[Any, np.dtype[np.bool_]]:
     """
     Connected component analysis used by entropy_masker.
 
@@ -225,12 +225,13 @@ def _connected_components(
 
 
 def entropy_masker(
-    image: np.ndarray,
+    image: npt.NDArray,
     footprint: Union[np.ndarray, None] = None,
     bins: int = 30,
     threshold_bounds: tuple[int, int] = (1, 4),
     connectivity: Union[int, None] = None,
     num_largest_components: Union[int, None] = None,
+) -> np.ndarray[Any, np.dtype[np.bool_]]:
     """
     Extract foreground from background from H&E WSIs and HHG images using the EntropyMasker algorithm [1].
     Connected component analysis to select the largest component(s) is optional.
@@ -284,6 +285,7 @@ def entropy_masker(
     else:
         # If no threshold was within bounds,
         # return full image.
+        mask = np.ones_like(gray, dtype=np.bool_)
 
     if connectivity and num_largest_components:
         return _connected_components(mask, connectivity, num_largest_components)

--- a/dlup/background.py
+++ b/dlup/background.py
@@ -24,11 +24,11 @@ import numpy as np
 import numpy.typing as npt
 import PIL.Image
 import scipy.ndimage as ndi
+import scipy.signal
 import skimage.filters
 import skimage.measure
 import skimage.morphology
 import skimage.segmentation
-from scipy.signal import argrelextrema
 
 import dlup
 import dlup.tiling
@@ -274,15 +274,15 @@ def entropy_masker(
 
     # Get the local minimum of the entropy histogram.
     # Corresponding entropy is the threshold below which
-    # data is considere background.
+    # data is considered background.
     hist, bin_edges = np.histogram(ent, bins)
-    minimum = argrelextrema(hist, np.less)
+    minimum = scipy.signal.argrelmin(hist)
     for threshold in bin_edges[minimum]:
         if threshold_bounds[0] < threshold < threshold_bounds[1]:
             mask = ent > threshold
             break
     else:
-        # If no threshold threshold was within bounds,
+        # If no threshold was within bounds,
         # return full image.
 
     if connectivity and num_largest_components:

--- a/dlup/background.py
+++ b/dlup/background.py
@@ -177,7 +177,7 @@ def fesi(image: np.ndarray) -> np.ndarray:
 
 def entropy_masker(
     image: np.ndarray,
-    footprint: Union[np.ndarray, tuple, None] = None,
+    footprint: Union[np.ndarray, None] = None,
     bins: int = 30,
     threshold_bounds: tuple[int, int] = (1, 4),
 ) -> np.ndarray:
@@ -188,7 +188,7 @@ def entropy_masker(
     ----------
     image : np.ndarray
         2D RGB image, with color channels at the last axis.
-    footprint : np.ndarray, tuple, default=`skimage.morphology.disk(3)`
+    footprint : np.ndarray, default=`skimage.morphology.disk(3)`
         Footprint to use with `skimage.filters.rank.entropy`.
     bins : int
         Number of bins for the entropy histogram.

--- a/dlup/background.py
+++ b/dlup/background.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from enum import Enum
 from functools import partial
-from typing import Callable, Iterable, Union, Any
+from typing import Any, Callable, Iterable, Union
 
 import numpy as np
 import numpy.typing as npt

--- a/dlup/background.py
+++ b/dlup/background.py
@@ -26,7 +26,6 @@ import scipy.ndimage as ndi
 import skimage.filters
 import skimage.morphology
 import skimage.segmentation
-import skimage.util
 from scipy.signal import argrelextrema
 
 import dlup

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     author_email="j.teuwen@nki.nl",
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
-    python_requires=">=3.10",
+    python_requires=">=3.8",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Hi, thanks for the nice package. We use it for higher harmonic generation images.

**Problem**: the tissue in our higher harmonic images (three channels: THG, SHG and 2PEF, see below) is not well extracted by the (improved) FESI algorithm. At one side, it is too aggressive, while it leaves the background at the other side, because the tissue may sometimes touch the border of the image.

**Solution**: use the EntropyMasker [1] algorithm. In short: homogenous regions are considered background and heterogenous regions are considered foreground. EntropyMasker produces satisfactory results in about 5 seconds for an image thumbnail with size 2048x1068.

This pull request is an unofficial reimplementation of the relevant function of https://github.com/CirculatoryHealth/EntropyMasker.

[1] Song, Y., Cisternino, F., Mekke, J.M. et al. An automatic entropy method to efficiently mask histology whole-slide images. Sci Rep 13, 4321 (2023). https://doi.org/10.1038/s41598-023-29638-1

Original image
![image](https://user-images.githubusercontent.com/28396796/225709745-dff2899d-7bcc-4429-bc87-b6029e5a2155.png)

FESI
![image](https://user-images.githubusercontent.com/28396796/225711720-481daa07-9273-4a5d-b4a3-3e57a21cd869.png)

Improved FESI
![image](https://user-images.githubusercontent.com/28396796/225714967-abf5d12a-4828-4015-8544-3bfb0eb3476b.png)

EntropyMasker
![image](https://user-images.githubusercontent.com/28396796/225714240-a8788767-f6a3-4b7d-be56-6986ffc9d10a.png)

<details>
<summary>How the above images are generated</summary>

From the docs.

```python
from dlup.data.dataset import TiledROIsSlideImageDataset
from dlup import SlideImage
import matplotlib.pyplot as plt
from PIL import Image, ImageDraw
import numpy as np
from dlup.background import get_mask, entropy_masker, fesi, improved_fesi
from dlup.experimental_backends import ImageBackend
import time

INPUT_FILE_PATH = "path/to/image/file.tif"
slide_image = SlideImage.from_file_path(INPUT_FILE_PATH)
slide_image.get_thumbnail()

TILE_SIZE = (224, 224)
TARGET_MPP = 0.2

# Generate the mask
mask = get_mask(slide_image, entropy_masker|fesi|improved_fesi)
scaled_region_view = slide_image.get_scaled_view(slide_image.get_scaling(TARGET_MPP))

dataset = TiledROIsSlideImageDataset.from_standard_tiling(INPUT_FILE_PATH, TARGET_MPP, TILE_SIZE, (0, 0), mask=mask)
background = Image.new("RGBA", tuple(scaled_region_view.size), (255, 255, 255, 255))

for d in dataset:
    tile = d["image"]
    coords = np.array(d["coordinates"])
    box = tuple(np.array((*coords, *(coords + TILE_SIZE))).astype(int))
    background.paste(tile, box)
    draw = ImageDraw.Draw(background)

plt.figure()
plt.imshow(background)
plt.show()
```
</details>