### PR TITLE
Implement enhancement requested in {#175}

### DIFF
--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -77,6 +77,19 @@ class GeoJsonDict(TypedDict):
     features: list[dict[str, str | dict[str, str]]]
 
 
+class AbstractRegionView(ABC):
+    """
+    An abstract object which can be used to extract a specific annotation region.
+    """
+    def read_region(self, location: GenericFloatArray, size: GenericIntArray):
+        return self._read_region_impl(location, size)
+
+    @abstractmethod
+    def _read_region_impl(self, location: GenericFloatArray, size: GenericIntArray) -> PIL.Image.Image:
+        """Define a method to return an annotation object containing the region."""
+        pass
+
+
 class Point(shapely.geometry.Point):  # type: ignore
     # https://github.com/shapely/shapely/issues/1233#issuecomment-1034324441
     _id_to_attrs: ClassVar[dict[str, Any]] = {}
@@ -167,7 +180,7 @@ class Polygon(shapely.geometry.Polygon):  # type: ignore
         return f"{self.annotation_class}, {self.wkt}"
 
 
-class _AnnotationRegionView(ABC):
+class _AnnotationRegionView(AbstractRegionView):
     """
     This is a special class for viewing specific regions of the annotations.
     """
@@ -176,7 +189,7 @@ class _AnnotationRegionView(ABC):
         self._annotations = annotations
         self._scaling = scaling
 
-    def read_region(self, location: GenericFloatArray, size: GenericIntArray) -> list[Polygon | Point]:
+    def _read_region_impl(self, location: GenericFloatArray, size: GenericIntArray) -> list[Polygon | Point]:
         """Returns an annotation region of the level associated to the view."""
         x, y = location
         w, h = size

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -186,6 +186,7 @@ class _AnnotationRegionView(AbstractRegionView):
     """
     def __init__(self, annotations: WsiAnnotations, scaling: GenericNumber):
         """Initialize with a WsiAnnotations object and the scaling level."""
+        super().__init__()
         self._annotations = annotations
         self._scaling = scaling
 

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -168,11 +168,10 @@ class Polygon(shapely.geometry.Polygon):  # type: ignore
 
 
 class _AnnotationRegionView(ABC):
-    def __init__(
-        self,
-        annotations: WsiAnnotations,
-        scaling: GenericNumber,
-    ):
+    """
+    This is a special class for viewing specific regions of the annotations.
+    """
+    def __init__(self, annotations: WsiAnnotations, scaling: GenericNumber):
         """Initialize with a WsiAnnotations object and the scaling level."""
         self._annotations = annotations
         self._scaling = scaling

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import copy
 import errno
-from abc import ABC
+from abc import ABC, abstractmethod
 import json
 import os
 import pathlib

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -857,6 +857,26 @@ class WsiAnnotations:
                 output.append(self._cast(annotation_class, annotation))
         return output
 
+    def get_scaled_view(self, scaling: float, region_size: tuple) -> list[Polygon | Point]:
+        """
+        Obtain the scaled view of annotations of a particular region.
+
+        Parameters
+        ----------
+        scaling: float
+            The scaling at which the view is requested.
+
+        region_size: tuple
+            The region size within the annotations which needs to be scaled and returned.
+
+        Returns
+        -------
+        scaled_region: List[Polygon | Point]
+            The scaled annotation region
+        """
+        scaled_region = self.read_region((0, 0), scaling=scaling, region_size=region_size)
+        return scaled_region
+
     def _cast(self, annotation_class: AnnotationClass, annotation: ShapelyTypes) -> Point | Polygon:
         """
         Cast the shapely object with annotation_name to internal format.

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -857,7 +857,7 @@ class WsiAnnotations:
                 output.append(self._cast(annotation_class, annotation))
         return output
 
-    def get_scaled_view(self, scaling: float, region_size: tuple) -> list[Polygon | Point]:
+    def get_scaled_view(self, scaling: float, region_size: npt.NDArray[np.int_ | np.float_]) -> list[Polygon | Point]:
         """
         Obtain the scaled view of annotations of a particular region.
 
@@ -866,7 +866,7 @@ class WsiAnnotations:
         scaling: float
             The scaling at which the view is requested.
 
-        region_size: tuple
+        region_size: npt.NDArray[np.int_ | np.float_]
             The region size within the annotations which needs to be scaled and returned.
 
         Returns

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -81,11 +81,12 @@ class AbstractRegionView(ABC):
     """
     An abstract object which can be used to extract a specific annotation region.
     """
-    def read_region(self, location: GenericFloatArray, size: GenericIntArray):
+
+    def read_region(self, location: GenericFloatArray, size: GenericIntArray) -> list[Polygon | Point]:
         return self._read_region_impl(location, size)
 
     @abstractmethod
-    def _read_region_impl(self, location: GenericFloatArray, size: GenericIntArray) -> PIL.Image.Image:
+    def _read_region_impl(self, location: GenericFloatArray, size: GenericIntArray) -> list[Polygon | Point]:
         """Define a method to return an annotation object containing the region."""
         pass
 
@@ -184,6 +185,7 @@ class _AnnotationRegionView(AbstractRegionView):
     """
     This is a special class for viewing specific regions of the annotations.
     """
+
     def __init__(self, annotations: WsiAnnotations, scaling: GenericNumber):
         """Initialize with a WsiAnnotations object and the scaling level."""
         super().__init__()

--- a/dlup/data/dataset.py
+++ b/dlup/data/dataset.py
@@ -337,7 +337,8 @@ class BaseWsiDataset(Dataset[Union[TileSample, Sequence[TileSample]]]):
         if self.annotations is not None:
             if not isinstance(self.annotations, WsiAnnotations):
                 raise NotImplementedError("Only WsiAnnotations are supported at the moment.")
-            sample["annotations"] = self.annotations.read_region(coordinates, scaling, region_size)
+            scaled_annotations = self.annotations.get_scaled_view(scaling=scaling)
+            sample["annotations"] = scaled_annotations.read_region(location=coordinates, size=region_size)
 
         if self.labels:
             sample["labels"] = {k: v for k, v in self.labels}


### PR DESCRIPTION
This PR implements a feature within the `WsiAnnotations()` class which can scale and return arbitray regions within the annotated portion of the WSI upon the user's request.

Refer {#175} for the detailed description of the issue. 