### PR TITLE
Bug fixes, initial work to support OpenSlide 4.0.0, improve type checking

### DIFF
--- a/dlup/_image.py
+++ b/dlup/_image.py
@@ -194,6 +194,7 @@ class SlideImage:
         """Close the underlying image."""
         self._wsi.close()
 
+    @property
     def color_profile(self) -> ImageCmsProfile | None:
         """Returns the ICC profile of the image.
 
@@ -216,7 +217,7 @@ class SlideImage:
         >>> intent = ImageCms.getDefaultIntent(wsi.color_profile)
         >>> transform = ImageCms.buildTransform(wsi.color_profile, to_profile, "RGBA", "RGBA", intent, 0)
         >>> # Now you can apply the transform to the region (or any other PIL image)
-        >>> ImageCms.applyTransform(image, transform, True)
+        >>> ImageCms.applyTransform(region, transform, True)
 
         Returns
         -------

--- a/dlup/_image.py
+++ b/dlup/_image.py
@@ -396,6 +396,10 @@ class SlideImage:
         region = region.resize(size, resample=self._interpolator, box=box)
         if self._apply_color_profile and self.color_profile is not None:
             PIL.ImageCms.applyTransform(region, self._color_transform, True)
+            # Remove the ICC profile from the region to make sure it's not applied twice by accident.
+            # Should always be available if a color profile is present.
+            del region.info["icc_profile"]
+
         return region
 
     def get_scaled_size(self, scaling: GenericNumber) -> tuple[int, int]:

--- a/dlup/_image.py
+++ b/dlup/_image.py
@@ -378,6 +378,12 @@ class SlideImage:
             (native_size_adapted[0], native_size_adapted[1]),
         )
 
+        if self._apply_color_profile and self.color_profile is not None:
+            PIL.ImageCms.applyTransform(region, self._color_transform, True)
+            # Remove the ICC profile from the region to make sure it's not applied twice by accident.
+            # Should always be available if a color profile is present.
+            del region.info["icc_profile"]
+
         # Within this region, there are a bunch of extra pixels, we interpolate to sample
         # the pixel in the right position to retain the right sample weight.
         # We also need to clip to the border, as some readers (e.g mirax) have one pixel less at the border.
@@ -394,12 +400,6 @@ class SlideImage:
         box = cast(tuple[float, float, float, float], box)
         size = cast(tuple[int, int], size)
         region = region.resize(size, resample=self._interpolator, box=box)
-        if self._apply_color_profile and self.color_profile is not None:
-            PIL.ImageCms.applyTransform(region, self._color_transform, True)
-            # Remove the ICC profile from the region to make sure it's not applied twice by accident.
-            # Should always be available if a color profile is present.
-            del region.info["icc_profile"]
-
         return region
 
     def get_scaled_size(self, scaling: GenericNumber) -> tuple[int, int]:

--- a/dlup/backends/common.py
+++ b/dlup/backends/common.py
@@ -7,6 +7,7 @@ from typing import Any
 import numpy as np
 import numpy.typing as npt
 import PIL.Image
+from PIL.ImageCms import ImageCmsProfile
 
 from dlup.types import GenericNumber, PathLike
 
@@ -171,6 +172,10 @@ class AbstractSlideBackend(abc.ABC):
     def slide_bounds(self) -> tuple[tuple[int, int], tuple[int, int]]:
         """Returns the bounds of the slide. These can be smaller than the image itself."""
         return (0, 0), self.dimensions
+
+    @property
+    def color_profile(self) -> ImageCmsProfile | None:
+        raise NotImplementedError("Color profiles are currently not implemented in this backend.")
 
     @property
     @abc.abstractmethod

--- a/dlup/data/dataset.py
+++ b/dlup/data/dataset.py
@@ -179,8 +179,10 @@ LRU_CACHE_SIZE = 32
 
 
 @functools.lru_cache(LRU_CACHE_SIZE)
-def _get_cached_slide_image(path: pathlib.Path, backend: ImageBackend, **kwargs: Any) -> "SlideImage":
-    return SlideImage.from_file_path(path, backend=backend, **kwargs)
+def _get_cached_slide_image(
+    path: pathlib.Path, backend: ImageBackend, apply_color_profile: bool, **kwargs: Any
+) -> "SlideImage":
+    return SlideImage.from_file_path(path, backend=backend, apply_color_profile=apply_color_profile, **kwargs)
 
 
 class BaseWsiDataset(Dataset[Union[TileSample, Sequence[TileSample]]]):
@@ -204,6 +206,7 @@ class BaseWsiDataset(Dataset[Union[TileSample, Sequence[TileSample]]]):
         annotations: list[_AnnotationTypes] | _AnnotationTypes | None = None,
         labels: list[tuple[str, _LabelTypes]] | None = None,
         backend: ImageBackend = ImageBackend.PYVIPS,
+        apply_color_profile: bool = False,
         **kwargs: Any,
     ):
         """
@@ -227,8 +230,12 @@ class BaseWsiDataset(Dataset[Union[TileSample, Sequence[TileSample]]]):
             Image-level labels. Will be added to each individual tile.
         transform :
             Transforming function. To be used for augmentations or other model specific preprocessing.
-        **kwargs :
-            Keyword arguments get passed to the underlying slide image.
+        backend : ImageBackend
+           Backend to pass to SlideImage
+        apply_color_profile : bool
+            Whether to apply the ICC profile to the image if available.
+        **kwargs : Any
+            Passed to SlideImage
         """
         # We need to reuse the pah in order to re-open the image if necessary.
         self._path = path
@@ -238,6 +245,7 @@ class BaseWsiDataset(Dataset[Union[TileSample, Sequence[TileSample]]]):
         self.annotations = annotations
         self.labels = labels
         self._backend = backend
+        self._apply_color_profile = apply_color_profile
         self._kwargs = kwargs
 
         # Maps from a masked index -> regions index.
@@ -264,7 +272,9 @@ class BaseWsiDataset(Dataset[Union[TileSample, Sequence[TileSample]]]):
     @property
     def slide_image(self) -> "SlideImage":
         """Return the cached slide image instance associated with this dataset."""
-        return _get_cached_slide_image(self.path, self._backend, **self._kwargs)
+        return _get_cached_slide_image(
+            self.path, backend=self._backend, apply_color_profile=self._apply_color_profile, **self._kwargs
+        )
 
     @overload
     def __getitem__(self, index: int) -> TileSample:

--- a/dlup/data/dataset.py
+++ b/dlup/data/dataset.py
@@ -383,7 +383,7 @@ class TiledWsiDataset(BaseWsiDataset):
         annotations: _AnnotationTypes | None = None,
         labels: list[tuple[str, _LabelTypes]] | None = None,
         transform: Callable[[RegionFromWsiDatasetSample], RegionFromWsiDatasetSample] | None = None,
-        backend: ImageBackend = ImageBackend.PYVIPS,
+        backend: ImageBackend = ImageBackend.OPENSLIDE,
         **kwargs: Any,
     ) -> None:
         self._grids = grids

--- a/dlup/experimental_backends/openslide_backend.py
+++ b/dlup/experimental_backends/openslide_backend.py
@@ -60,7 +60,7 @@ class OpenSlideSlide(openslide.OpenSlide, AbstractSlideBackend):
 
         mpp_x, mpp_y = value
         check_if_mpp_is_valid(mpp_x, mpp_y)
-        mpp = np.array([mpp_y, mpp_x])
+        mpp = np.array([mpp_x, mpp_y])
         self._spacings = [cast(tuple[float, float], tuple(mpp * downsample)) for downsample in self.level_downsamples]
 
     @property

--- a/dlup/experimental_backends/openslide_backend.py
+++ b/dlup/experimental_backends/openslide_backend.py
@@ -2,11 +2,14 @@
 # Copyright (c) dlup contributors
 from __future__ import annotations
 
+import warnings
+from distutils.version import LooseVersion
 from typing import cast
 
 import numpy as np
 import openslide
 import PIL.Image
+from PIL.ImageCms import ImageCmsProfile
 
 from dlup.backends.common import AbstractSlideBackend
 from dlup.types import PathLike
@@ -71,6 +74,26 @@ class OpenSlideSlide(openslide.OpenSlide, AbstractSlideBackend):
         if value is not None:
             return int(value)
         return value
+
+    @property
+    def color_profile(self) -> ImageCmsProfile | None:
+        """
+        Returns the color profile of the image if available. Otherwise returns None.
+
+        Returns
+        -------
+        ImageCmsProfile, optional
+            The color profile of the image.
+        """
+        if LooseVersion(openslide.__library_version__) < LooseVersion("4.0.0"):
+            warnings.warn(
+                "Color profile support is only available for openslide >= 4.0.0. "
+                f"You have version {openslide.__library_version__}. "
+                "Please update your openslide installation if you want to use this feature (recommended)."
+            )
+            return None
+
+        return super().color_profile
 
     @property
     def vendor(self) -> str:

--- a/dlup/experimental_backends/openslide_backend.py
+++ b/dlup/experimental_backends/openslide_backend.py
@@ -38,6 +38,7 @@ class OpenSlideSlide(openslide.OpenSlide, AbstractSlideBackend):
             Path to image.
         """
         super().__init__(str(filename))
+        self._spacings = None
 
         try:
             mpp_x = float(self.properties[openslide.PROPERTY_NAME_MPP_X])

--- a/dlup/experimental_backends/tifffile_backend.py
+++ b/dlup/experimental_backends/tifffile_backend.py
@@ -60,7 +60,7 @@ class TifffileSlide(AbstractSlideBackend):
 
             mpp_x = unit_dict[unit] / x_res
             mpp_y = unit_dict[unit] / y_res
-            self._spacings.append((mpp_y, mpp_x))
+            self._spacings.append((mpp_x, mpp_y))
 
             if idx >= 1:
                 downsample = mpp_x / self._spacings[0][0]

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ install_requires = [
     "pyvips>=2.2.1",
     "tqdm",
     "pillow>=9.2.0",
-    "openslide-python",
+    "openslide-python>=1.3.1",
     "opencv-python>=4.8.1.78",
     "shapely>=2.0.0",
 ]

--- a/tests/common.py
+++ b/tests/common.py
@@ -96,6 +96,13 @@ class OpenSlideImageMock(openslide.ImageSlide):
     def level_dimensions(self):
         return self._level_dimensions
 
+    @property
+    def level_spacings(self):
+        spacing = self.spacing
+        return tuple(
+            (spacing[0] * downsample**2, spacing[1] * downsample**2) for downsample in self.level_downsamples
+        )
+
     def get_level_image(self, level):
         return self.image.resize(self.level_dimensions[level])
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -161,6 +161,16 @@ class TestSlideImage:
         size = dlup_wsi.get_scaled_size(0.5)
         assert (np.array(size) >= 0).all()
 
+    @pytest.mark.parametrize("mpp", [0.57, 1.2, 4.4])
+    def test_get_closest_native_mpp(self, dlup_wsi, mpp):
+        """Check the scale is greater than zero."""
+        _mpp = dlup_wsi.get_closest_native_mpp(mpp)
+
+        if mpp in [0.57, 1.2]:
+            assert _mpp == (1.0, 1.0)
+        else:
+            assert _mpp == (4.0, 4.0)
+
     def test_thumbnail(self, dlup_wsi):
         """Check the thumbnail is a PIL Image."""
         thumbnail = dlup_wsi.thumbnail

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -8,6 +8,7 @@ import pytest
 import pyvips
 
 from dlup import SlideImage
+from dlup.experimental_backends import ImageBackend
 from dlup.utils.pyvips_utils import vips_to_numpy
 from dlup.writers import TiffCompression, TifffileImageWriter
 
@@ -49,6 +50,7 @@ def test_tiff_writer(shape, target_mpp):
 
         assert np.allclose(np.asarray(pil_image), vips_image_numpy)
 
-        with SlideImage.from_file_path(temp_tiff.name) as slide:
+        # OpenSlide does not read tiff mpp's correctly, so we use pyvips to check.
+        with SlideImage.from_file_path(temp_tiff.name, backend=ImageBackend.PYVIPS) as slide:
             slide_mpp = slide.mpp
             assert np.allclose(slide_mpp, target_mpp)


### PR DESCRIPTION
A few changes:
- OpenSlide 4.0.0 adds ICC profiles (see #184, #182); this is now included in SlideImage with the OPENSLIDE backend.
- `openslide-python` is updated
- Fix mpp_x <-> mpp_y problem also addressed in #183 (Closes #183)
- Change some **kwargs to parameters to enhance ability to type check
- Revert to using OpenSlide as default backend in the `SlideImage`. This is because currently it might be difficult to link libvips to openslide 4.0.0, and therefore it's tricky to test the ICC profile for pyvips.
- Fix a minor bug in `OpenSlideSlide` which crashed when no mpp value was found (now it will raise a `UnsupportedSlideError`)

To be able to solve #167 additional work needs to be performed in the dataset classes and in the `SlideImage` class