### PR TITLE
Fixes{#191}

### DIFF
--- a/dlup/_image.py
+++ b/dlup/_image.py
@@ -413,6 +413,11 @@ class SlideImage:
         use_limit_bounds: Optional[bool]
             If True, the scaled size will be calculated using the slide bounds of the whole slide image.
             This is generally the specific area within a whole slide image where we can find the tissue specimen.
+
+        Returns
+        -------
+        size: tuple[int, int]
+            The scaled size of the image.
         """
         if use_limit_bounds:
             _, bounded_size = self.slide_bounds

--- a/dlup/_image.py
+++ b/dlup/_image.py
@@ -408,7 +408,7 @@ class SlideImage:
             _, bounded_size = self.slide_bounds
             size = int(bounded_size[0] * scaling), int(bounded_size[1] * scaling)
         else:
-            size = int(self.size[0]) * scaling, int(self.size[1]) * scaling
+            size = int(self.size[0] * scaling), int(self.size[1] * scaling)
         return size
 
     def get_mpp(self, scaling: float) -> float:

--- a/dlup/_image.py
+++ b/dlup/_image.py
@@ -402,10 +402,15 @@ class SlideImage:
         region = region.resize(size, resample=self._interpolator, box=box)
         return region
 
-    def get_scaled_size(self, scaling: GenericNumber) -> tuple[int, int]:
+    def get_scaled_size(self, scaling: GenericNumber, use_limit_bounds: Optional[bool] = False) -> tuple[int, int]:
         """Compute slide image size at specific scaling."""
-        size = np.array(self.size) * scaling
-        return cast(tuple[int, int], tuple(size.astype(int)))
+        if use_limit_bounds:
+            bounded_size = self.bounded_size
+            size = int(bounded_size[0] * scaling), int(bounded_size[1] * scaling)
+        else:
+            size = np.array(self.size) * scaling
+            cast(tuple[int, int], tuple(size.astype(int)))
+        return size
 
     def get_mpp(self, scaling: float) -> float:
         """Returns the respective mpp from the scaling."""
@@ -481,6 +486,12 @@ class SlideImage:
     def size(self) -> tuple[int, int]:
         """Returns the highest resolution image size in pixels. Returns in (width, height)."""
         return self._wsi.dimensions
+
+    @property
+    def bounded_size(self) -> tuple[int, ...]:
+        """Returns the effective size of the wsi considering the slide bounds property"""
+        _, bounded_size = self._wsi.slide_bounds
+        return int(bounded_size[0]), int(bounded_size[1])
 
     @property
     def mpp(self) -> float:

--- a/dlup/_image.py
+++ b/dlup/_image.py
@@ -405,11 +405,10 @@ class SlideImage:
     def get_scaled_size(self, scaling: GenericNumber, use_limit_bounds: Optional[bool] = False) -> tuple[int, int]:
         """Compute slide image size at specific scaling."""
         if use_limit_bounds:
-            bounded_size = self.bounded_size
+            _, bounded_size = self.slide_bounds
             size = int(bounded_size[0] * scaling), int(bounded_size[1] * scaling)
         else:
-            size = np.array(self.size) * scaling
-            cast(tuple[int, int], tuple(size.astype(int)))
+            size = int(self.size[0]) * scaling, int(self.size[1]) * scaling
         return size
 
     def get_mpp(self, scaling: float) -> float:
@@ -486,12 +485,6 @@ class SlideImage:
     def size(self) -> tuple[int, int]:
         """Returns the highest resolution image size in pixels. Returns in (width, height)."""
         return self._wsi.dimensions
-
-    @property
-    def bounded_size(self) -> tuple[int, ...]:
-        """Returns the effective size of the wsi considering the slide bounds property"""
-        _, bounded_size = self._wsi.slide_bounds
-        return int(bounded_size[0]), int(bounded_size[1])
 
     @property
     def mpp(self) -> float:

--- a/dlup/_image.py
+++ b/dlup/_image.py
@@ -403,7 +403,17 @@ class SlideImage:
         return region
 
     def get_scaled_size(self, scaling: GenericNumber, use_limit_bounds: Optional[bool] = False) -> tuple[int, int]:
-        """Compute slide image size at specific scaling."""
+        """Compute slide image size at specific scaling.
+
+        Parameters
+        -----------
+        scaling: GenericNumber
+            The factor by which the image needs to be scaled.
+
+        use_limit_bounds: Optional[bool]
+            If True, the scaled size will be calculated using the slide bounds of the whole slide image.
+            This is generally the specific area within a whole slide image where we can find the tissue specimen.
+        """
         if use_limit_bounds:
             _, bounded_size = self.slide_bounds
             size = int(bounded_size[0] * scaling), int(bounded_size[1] * scaling)


### PR DESCRIPTION
This PR implements:
1. Adds a boolean flag `use_limit_bounds` to the `SlideImage.get_scaled_size()` function which returns the scaled bounded size.
