### PR TITLE
Bug/fix slide bounds in TiffFile

### DIFF
--- a/dlup/_image.py
+++ b/dlup/_image.py
@@ -240,8 +240,9 @@ class SlideImage:
         if self.__color_transforms is None:
             to_profile = PIL.ImageCms.createProfile("sRGB")
             intent = PIL.ImageCms.getDefaultIntent(self.color_profile)
-            self.__color_transform = PIL.ImageCms.buildTransform(
-                self.color_profile, to_profile, "RGBA", "RGBA", intent, 0
+            self.__color_transform = cast(
+                PIL.ImageCms.ImageCmsTransform,
+                PIL.ImageCms.buildTransform(self.color_profile, to_profile, "RGBA", "RGBA", intent, 0),
             )
         return self.__color_transform
 

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -736,9 +736,9 @@ class WsiAnnotations:
 
     def read_region(
         self,
-        coordinates: npt.NDArray[np.int_ | np.float_] | tuple[GenericNumber, GenericNumber],
+        location: npt.NDArray[np.int_ | np.float_] | tuple[GenericNumber, GenericNumber],
         scaling: float,
-        region_size: npt.NDArray[np.int_ | np.float_] | tuple[GenericNumber, GenericNumber],
+        size: npt.NDArray[np.int_ | np.float_] | tuple[GenericNumber, GenericNumber],
     ) -> list[Polygon | Point]:
         """Reads the region of the annotations. API is the same as `dlup.SlideImage` so they can be used in conjunction.
 
@@ -757,8 +757,8 @@ class WsiAnnotations:
 
         Parameters
         ----------
-        coordinates: np.ndarray or tuple
-        region_size : np.ndarray or tuple
+        location: np.ndarray or tuple
+        size : np.ndarray or tuple
         scaling : float
 
         Returns
@@ -778,12 +778,12 @@ class WsiAnnotations:
         >>> wsi = wsi.get_scaled_view(scaling=0.5)
         >>> wsi = wsi.read_region(location=(0,0), size=wsi.size)
         >>> annotations = WsiAnnotations.from_geojson([Path("path/to/geojson.json")], labels=["class_name"])
-        >>> polygons: list[Polygons] = annotations.read_region(coordinates=(0,0), region_size=wsi.size, scaling=0.01)
+        >>> polygons: list[Polygons] = annotations.read_region(location=(0,0), size=wsi.size, scaling=0.01)
 
         The polygons can be converted to masks using `dlup.data.transforms.convert_annotations` or
         `dlup.data.transforms.ConvertAnnotationsToMask`.
         """
-        box = list(coordinates) + list(np.asarray(coordinates) + np.asarray(region_size))
+        box = list(location) + list(np.asarray(location) + np.asarray(size))
         box = (np.asarray(box) / scaling).tolist()
         query_box = geometry.box(*box)
 
@@ -828,8 +828,8 @@ class WsiAnnotations:
             0,
             0,
             scaling,
-            -coordinates[0],
-            -coordinates[1],
+            -location[0],
+            -location[1],
         ]
 
         output: list[Polygon | Point] = []

--- a/dlup/experimental_backends/tifffile_backend.py
+++ b/dlup/experimental_backends/tifffile_backend.py
@@ -47,9 +47,9 @@ class TifffileSlide(AbstractSlideBackend):
         for idx, page in enumerate(self._image.pages):
             # Remove channel dimension and swap rows and columns
             if len(page.shape) == 3:
-                self._shapes.append((page.shape[1], page.shape[2]))
+                self._shapes.append((page.shape[2], page.shape[1]))
             else:
-                self._shapes.append((page.shape[0], page.shape[1]))
+                self._shapes.append((page.shape[1], page.shape[0]))
 
             # TODO: The order of the x and y tag need to be verified
             x_res = page.tags["XResolution"].value  # type: ignore


### PR DESCRIPTION
The TiffFile had the axis swapped (height, width) instead of width, height. This fixes #187.

Also took the opportunity to change a few stylistic things.