### PR TITLE
Add an optional `colormap` parameter while writing tiff files.

### DIFF
--- a/dlup/background.py
+++ b/dlup/background.py
@@ -138,7 +138,7 @@ def _is_foreground_numpy(
         return False
 
     mask_tile[:clipped_h, :clipped_w] = np.asarray(
-        _background_mask.resize((clipped_w, clipped_h), PIL.Image.BICUBIC, box=box), dtype=float
+        _background_mask.resize((clipped_w, clipped_h), PIL.Image.Resampling.BICUBIC, box=box), dtype=float
     )
 
     if threshold == 1.0 and mask_tile.mean() == 1.0:

--- a/dlup/writers.py
+++ b/dlup/writers.py
@@ -245,10 +245,10 @@ class TifffileImageWriter(ImageWriter):
         **options: Any,
     ) -> None:
         native_resolution = 1 / np.array(self._mpp) * 10000
-        if is_rgb:
-            colorspace = "rgb"
-        elif self._colormap is not None:
+        if self._colormap is not None:
             colorspace = "palette"
+        elif is_rgb:
+            colorspace = "rgb"
         else:
             colorspace = "minisblack"
         tiff_writer.write(

--- a/dlup/writers.py
+++ b/dlup/writers.py
@@ -109,7 +109,7 @@ class TifffileImageWriter(ImageWriter):
         mpp: float | tuple[float, float],
         tile_size: tuple[int, int] = (512, 512),
         pyramid: bool = False,
-        colormap: npt.NDArray[np.uint16] | None = None,
+        colormap: dict[int, str] | None = None,
         compression: TiffCompression | None = TiffCompression.JPEG,
         interpolator: Resampling | None = Resampling.LANCZOS,
         anti_aliasing: bool = False,
@@ -132,7 +132,7 @@ class TifffileImageWriter(ImageWriter):
             Tiff tile_size, defined as (height, width).
         pyramid : bool
             Whether to write a pyramidal image.
-        colormap : np.ndarray
+        colormap : dict[int, str]
             Colormap to use for the image. This is only used when the image is a mask.
         compression : TiffCompression
             Compressor to use.
@@ -173,7 +173,7 @@ class TifffileImageWriter(ImageWriter):
         self._pyramid = pyramid
         self._quality = quality
         self._metadata = metadata
-        self._colormap = colormap
+        self._colormap = _color_dict_to_clut(colormap) if colormap is not None else None
 
     def from_pil(self, pil_image: PIL.Image.Image) -> None:
         """

--- a/dlup/writers.py
+++ b/dlup/writers.py
@@ -63,7 +63,7 @@ INTERPOLATOR_TO_VIPS: dict[int, Kernel] = {
 }
 
 
-def _color_dict_to_clut(color_map: dict[int, str]) -> npt.NDArray[np.uint16]:
+def _color_dict_to_color_lut(color_map: dict[int, str]) -> npt.NDArray[np.uint16]:
     """
     Convert a color map to a color look-up table (LUT).
 
@@ -173,7 +173,7 @@ class TifffileImageWriter(ImageWriter):
         self._pyramid = pyramid
         self._quality = quality
         self._metadata = metadata
-        self._colormap = _color_dict_to_clut(colormap) if colormap is not None else None
+        self._colormap = _color_dict_to_color_lut(colormap) if colormap is not None else None
 
     def from_pil(self, pil_image: PIL.Image.Image) -> None:
         """
@@ -228,7 +228,7 @@ class TifffileImageWriter(ImageWriter):
 
         is_rgb = self._size[-1] in (3, 4)
         if is_rgb and self._colormap is not None:
-            raise ValueError("Cannot use a colormap with an RGB image.")
+            raise ValueError("Colormaps only work with integer-valued images (e.g. masks).")
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_filename = pathlib.Path(temp_dir) / filename.name
             tiff_writer = tifffile.TiffWriter(temp_filename, bigtiff=True)

--- a/dlup/writers.py
+++ b/dlup/writers.py
@@ -245,12 +245,18 @@ class TifffileImageWriter(ImageWriter):
         **options: Any,
     ) -> None:
         native_resolution = 1 / np.array(self._mpp) * 10000
+        if is_rgb:
+            colorspace = "rgb"
+        elif self._colormap is not None:
+            colorspace = "palette"
+        else:
+            colorspace = "minisblack"
         tiff_writer.write(
             tile_iterator,  # noqa
             shape=(*shapes[level], self._size[-1]) if is_rgb else (*shapes[level], 1),
             dtype="uint8",
             resolution=(*native_resolution / 2**level, "CENTIMETER"),
-            photometric="rgb" if is_rgb else "minisblack",
+            photometric=colorspace,
             compression=compression if not self._quality else (compression, self._quality),  # type: ignore
             tile=self._tile_size,
             colormap=self._colormap,

--- a/dlup/writers.py
+++ b/dlup/writers.py
@@ -76,6 +76,7 @@ class TifffileImageWriter(ImageWriter):
         mpp: float | tuple[float, float],
         tile_size: tuple[int, int] = (512, 512),
         pyramid: bool = False,
+        colormap: npt.NDArray[np.uint16] | None = None,
         compression: TiffCompression | None = TiffCompression.JPEG,
         interpolator: Resampling | None = Resampling.LANCZOS,
         anti_aliasing: bool = False,
@@ -98,6 +99,8 @@ class TifffileImageWriter(ImageWriter):
             Tiff tile_size, defined as (height, width).
         pyramid : bool
             Whether to write a pyramidal image.
+        colormap : np.ndarray
+            Colormap to use for the image. This is only used when the image is a mask.
         compression : TiffCompression
             Compressor to use.
         interpolator : Resampling, optional
@@ -137,6 +140,7 @@ class TifffileImageWriter(ImageWriter):
         self._pyramid = pyramid
         self._quality = quality
         self._metadata = metadata
+        self._colormap = colormap
 
     def from_pil(self, pil_image: PIL.Image.Image) -> None:
         """
@@ -249,6 +253,7 @@ class TifffileImageWriter(ImageWriter):
             photometric="rgb" if is_rgb else "minisblack",
             compression=compression if not self._quality else (compression, self._quality),  # type: ignore
             tile=self._tile_size,
+            colormap=self._colormap,
             **options,
         )
 

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -33,9 +33,9 @@ def _color_dict_to_clut(color_map: dict[int, str]) -> tuple[np.ndarray, dict[int
 
 
 color_map = {
-    1: "green",  # Green for stroma
-    2: "red",  # Red for tumor
-    3: "yellow",  # Yellow for ignore
+    1: "green",
+    2: "red",
+    3: "yellow",
 }
 clut, rgb_color_map = _color_dict_to_clut(color_map)
 

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -15,7 +15,6 @@ from PIL import ImageColor
 
 
 class TestTiffWriter:
-
     def __init__(self):
         color_map = {
             1: "green",  # Green for stroma

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -96,7 +96,7 @@ class TestTiffWriter:
                 size=size,
                 mpp=(target_mpp, target_mpp),
                 compression=TiffCompression.NONE,
-                colormap=clut,
+                colormap=color_map,
             )
 
             writer.from_pil(pil_image)

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -3,9 +3,9 @@
 import tempfile
 
 import numpy as np
-from PIL import Image, ImageColor
 import pytest
 import pyvips
+from PIL import Image, ImageColor
 
 from dlup import SlideImage
 from dlup.experimental_backends import ImageBackend

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -21,15 +21,18 @@ class TestTiffWriter:
             2: "red",  # Red for tumor
             3: "yellow",  # Yellow for ignore
         }
+        self.clut = self._color_dict_to_clut(color_map)
 
+    def _color_dict_to_clut(self, color_map: dict[int, str]) -> np.ndarray:
         # Convert color names to RGB values
         self.rgb_color_map = {index: ImageColor.getrgb(color_name) for index, color_name in color_map.items()}
 
         # Initialize a 3x256 CLUT (for 8-bit images)
-        self.clut = np.zeros((3, 256), dtype=np.uint16)
+        clut = np.zeros((3, 256), dtype=np.uint16)
         for index, color in self.rgb_color_map.items():
             for i, c in enumerate(color):
-                self.clut[i, index] = c * 256  # Scale to 16-bit color depth (tifffile uses 0-65535 range for RGB)
+                clut[i, index] = c * 256  # Scale to 16-bit color depth (tifffile uses 0-65535 range for RGB)
+        return clut
 
     @pytest.mark.parametrize(
         ["shape", "target_mpp"],

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -3,7 +3,7 @@
 import tempfile
 
 import numpy as np
-import PIL.Image
+from PIL import Image, ImageColor
 import pytest
 import pyvips
 
@@ -11,7 +11,6 @@ from dlup import SlideImage
 from dlup.experimental_backends import ImageBackend
 from dlup.utils.pyvips_utils import vips_to_numpy
 from dlup.writers import TiffCompression, TifffileImageWriter
-from PIL import ImageColor
 
 
 def _color_dict_to_clut(color_map: dict[int, str]) -> tuple[np.ndarray, dict[int, tuple[int, int, int]]]:
@@ -55,7 +54,7 @@ class TestTiffWriter:
     )
     def test_tiff_writer(self, shape, target_mpp):
         random_array = np.random.randint(low=0, high=255, size=shape, dtype=np.uint8)
-        pil_image = PIL.Image.fromarray(random_array, mode="RGB" if len(shape) == 3 else "L")
+        pil_image = Image.fromarray(random_array, mode="RGB" if len(shape) == 3 else "L")
         mode = pil_image.mode
 
         if mode == "L":
@@ -101,7 +100,7 @@ class TestTiffWriter:
         random_array[256:512, 0:256] = 2
         # Bottom-right region with 3
         random_array[256:512, 256:512] = 3
-        pil_image = PIL.Image.fromarray(random_array, mode="RGB" if len(shape) == 3 else "L")
+        pil_image = Image.fromarray(random_array, mode="RGB" if len(shape) == 3 else "L")
         mode = pil_image.mode
 
         if mode == "L":

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -32,15 +32,15 @@ def _color_dict_to_clut(color_map: dict[int, str]) -> tuple[np.ndarray, dict[int
     return clut, rgb_color_map
 
 
-class TestTiffWriter:
-    def __init__(self):
-        color_map = {
-            1: "green",  # Green for stroma
-            2: "red",  # Red for tumor
-            3: "yellow",  # Yellow for ignore
-        }
-        self.clut, self.rgb_color_map = _color_dict_to_clut(color_map)
+color_map = {
+    1: "green",  # Green for stroma
+    2: "red",  # Red for tumor
+    3: "yellow",  # Yellow for ignore
+}
+clut, rgb_color_map = _color_dict_to_clut(color_map)
 
+
+class TestTiffWriter:
     @pytest.mark.parametrize(
         ["shape", "target_mpp"],
         [
@@ -114,7 +114,7 @@ class TestTiffWriter:
                 size=size,
                 mpp=(target_mpp, target_mpp),
                 compression=TiffCompression.NONE,
-                colormap=self.clut,
+                colormap=clut,
             )
 
             writer.from_pil(pil_image)
@@ -124,8 +124,8 @@ class TestTiffWriter:
                 thumbnail = slide.get_thumbnail(size=shape)
                 assert np.allclose(slide_mpp, target_mpp)
                 top_right = np.asarray(thumbnail).astype(np.uint8)[0:256, 256:512]
-                assert np.all(top_right == self.rgb_color_map[1])
+                assert np.all(top_right == rgb_color_map[1])
                 bottom_left = np.asarray(thumbnail).astype(np.uint8)[256:512, 0:256]
-                assert np.all(bottom_left == self.rgb_color_map[2])
+                assert np.all(bottom_left == rgb_color_map[2])
                 bottom_right = np.asarray(thumbnail).astype(np.uint8)[256:512, 256:512]
-                assert np.all(bottom_right == self.rgb_color_map[3])
+                assert np.all(bottom_right == rgb_color_map[3])

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -120,7 +120,7 @@ class TestTiffWriter:
 
         with tempfile.NamedTemporaryFile(suffix=".tiff") as temp_tiff:
             writer = TifffileImageWriter(
-                temp_tiff.name, size=size, mpp=(0.25, 0.25), compression=TiffCompression.NONE, colormap=clut
+                temp_tiff.name, size=size, mpp=(0.25, 0.25), compression=TiffCompression.NONE, colormap=color_map
             )
             with pytest.raises(ValueError, match="Cannot use a colormap with an RGB image."):
                 writer.from_pil(pil_image)

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -11,47 +11,112 @@ from dlup import SlideImage
 from dlup.experimental_backends import ImageBackend
 from dlup.utils.pyvips_utils import vips_to_numpy
 from dlup.writers import TiffCompression, TifffileImageWriter
+from PIL import ImageColor
 
 
-@pytest.mark.parametrize(
-    ["shape", "target_mpp"],
-    [
-        [(1024, 1024, 3), 0.45],
-        [(512, 768, 3), 4],
-        [(1024, 512, 3), 0.25],
-        [(1024, 1024), 10],
-        [(512, 768), 0.8],
-        [(1024, 512), 0.7],
-    ],
-)
-def test_tiff_writer(shape, target_mpp):
-    random_array = np.random.randint(low=0, high=255, size=shape, dtype=np.uint8)
-    pil_image = PIL.Image.fromarray(random_array, mode="RGB" if len(shape) == 3 else "L")
-    mode = pil_image.mode
+class TestTiffWriter:
 
-    if mode == "L":
-        size = pil_image.size
-    else:
-        size = (*pil_image.size, 3)
+    def __init__(self):
+        color_map = {
+            1: "green",  # Green for stroma
+            2: "red",  # Red for tumor
+            3: "yellow",  # Yellow for ignore
+        }
 
-    with tempfile.NamedTemporaryFile(suffix=".tiff") as temp_tiff:
-        writer = TifffileImageWriter(
-            temp_tiff.name,
-            size=size,
-            mpp=(target_mpp, target_mpp),
-            compression=TiffCompression.NONE,
-        )
+        # Convert color names to RGB values
+        self.rgb_color_map = {index: ImageColor.getrgb(color_name) for index, color_name in color_map.items()}
 
-        writer.from_pil(pil_image)
-        vips_image = pyvips.Image.new_from_file(temp_tiff.name)
-        vips_image_numpy = vips_to_numpy(vips_image)
+        # Initialize a 3x256 CLUT (for 8-bit images)
+        self.clut = np.zeros((3, 256), dtype=np.uint16)
+        for index, color in self.rgb_color_map.items():
+            for i, c in enumerate(color):
+                self.clut[i, index] = c * 256  # Scale to 16-bit color depth (tifffile uses 0-65535 range for RGB)
+
+    @pytest.mark.parametrize(
+        ["shape", "target_mpp"],
+        [
+            [(1024, 1024, 3), 0.45],
+            [(512, 768, 3), 4],
+            [(1024, 512, 3), 0.25],
+            [(1024, 1024), 10],
+            [(512, 768), 0.8],
+            [(1024, 512), 0.7],
+        ],
+    )
+    def test_tiff_writer(self, shape, target_mpp):
+        random_array = np.random.randint(low=0, high=255, size=shape, dtype=np.uint8)
+        pil_image = PIL.Image.fromarray(random_array, mode="RGB" if len(shape) == 3 else "L")
+        mode = pil_image.mode
+
         if mode == "L":
-            vips_image_numpy = vips_image_numpy[..., 0]
+            size = pil_image.size
+        else:
+            size = (*pil_image.size, 3)
 
-        assert np.allclose(np.asarray(pil_image), vips_image_numpy)
+        with tempfile.NamedTemporaryFile(suffix=".tiff") as temp_tiff:
+            writer = TifffileImageWriter(
+                temp_tiff.name,
+                size=size,
+                mpp=(target_mpp, target_mpp),
+                compression=TiffCompression.NONE,
+            )
 
-        # OpenSlide does not read tiff mpp's correctly, so we use pyvips to check.
-        # TODO: 4.0.0 does.
-        with SlideImage.from_file_path(temp_tiff.name, backend=ImageBackend.PYVIPS) as slide:
-            slide_mpp = slide.mpp
-            assert np.allclose(slide_mpp, target_mpp)
+            writer.from_pil(pil_image)
+            vips_image = pyvips.Image.new_from_file(temp_tiff.name)
+            vips_image_numpy = vips_to_numpy(vips_image)
+            if mode == "L":
+                vips_image_numpy = vips_image_numpy[..., 0]
+
+            assert np.allclose(np.asarray(pil_image), vips_image_numpy)
+
+            # OpenSlide does not read tiff mpp's correctly, so we use pyvips to check.
+            # TODO: 4.0.0 does.
+            with SlideImage.from_file_path(temp_tiff.name, backend=ImageBackend.PYVIPS) as slide:
+                slide_mpp = slide.mpp
+                assert np.allclose(slide_mpp, target_mpp)
+
+    @pytest.mark.parametrize(
+        ["shape", "target_mpp"],
+        [
+            [(512, 512), 0.25],
+        ],
+    )
+    def test_color_map(self, shape, target_mpp):
+        random_array = np.zeros(shape, dtype=np.uint8)
+        # Fill regions with 0, 1, 2, 3
+        # Top-left region with 0 (already filled since the array is initialized with zeros)
+        # Top-right region with 1
+        random_array[0:256, 256:512] = 1
+        # Bottom-left region with 2
+        random_array[256:512, 0:256] = 2
+        # Bottom-right region with 3
+        random_array[256:512, 256:512] = 3
+        pil_image = PIL.Image.fromarray(random_array, mode="RGB" if len(shape) == 3 else "L")
+        mode = pil_image.mode
+
+        if mode == "L":
+            size = pil_image.size
+        else:
+            size = (*pil_image.size, 3)
+
+        with tempfile.NamedTemporaryFile(suffix=".tiff") as temp_tiff:
+            writer = TifffileImageWriter(
+                temp_tiff.name,
+                size=size,
+                mpp=(target_mpp, target_mpp),
+                compression=TiffCompression.NONE,
+                colormap=self.clut,
+            )
+
+            writer.from_pil(pil_image)
+
+            with SlideImage.from_file_path(temp_tiff.name, backend=ImageBackend.PYVIPS) as slide:
+                slide_mpp = slide.mpp
+                thumbnail = slide.get_thumbnail(size=shape)
+                assert np.allclose(slide_mpp, target_mpp)
+                top_right = np.asarray(thumbnail).astype(np.uint8)[0:256, 256:512]
+                assert np.all(top_right == self.rgb_color_map[1])
+                bottom_left = np.asarray(thumbnail).astype(np.uint8)[256:512, 0:256]
+                assert np.all(bottom_left == self.rgb_color_map[2])
+                bottom_right = np.asarray(thumbnail).astype(np.uint8)[256:512, 256:512]
+                assert np.all(bottom_right == self.rgb_color_map[3])


### PR DESCRIPTION
Fixes {#212}

This PR adds an optional `colormap` tag to this tiff writer which helps us store colors corresponding to index values in case the tiff file being written is a mask. Adding this will allow third party applications such as FIJI, ASAP or Slidescore to automatically apply the color look up table while opening the tiff file. Below are screenshots of viewing a test image in these viewers:

1. ASAP

![image](https://github.com/NKI-AI/dlup/assets/26798611/feff3083-9bb1-45d7-b758-34b37192de53)

2. FIJI

![image](https://github.com/NKI-AI/dlup/assets/26798611/fa94eb18-3af2-4b43-9db8-0637e5ade832)

3. slidescore

![image](https://github.com/NKI-AI/dlup/assets/26798611/bba25586-51f7-4f6c-8cac-ed0fc0d37c09)


