### PR TITLE
Bugfix/multiclass flag

### DIFF
--- a/dlup/data/transforms.py
+++ b/dlup/data/transforms.py
@@ -136,7 +136,8 @@ def convert_annotations(
 class ConvertAnnotationsToMask:
     """Transform which converts polygons to masks. Will overwrite the annotations key"""
 
-    def __init__(self, *, roi_name: str | None, index_map: dict[str, int], default_value: int = 0):
+    def __init__(self, *, roi_name: str | None, index_map: dict[str, int], multiclass: bool = False,
+                 default_value: int = 0):
         """
         Converts annotations given my `dlup.annotations.Polygon` or `dlup.annotations.Point` to a mask and a dictionary
         of points. The mask is initialized with `default_value`, (i.e., background). The values in the mask are
@@ -153,12 +154,15 @@ class ConvertAnnotationsToMask:
             Name of the ROI key.
         index_map : dict
             Dictionary mapping the label to the integer in the output.
+        multiclass: bool
+            Output a multiclass mask, the first axis will be the index. This requires that an index_map is available.
         default_value : int
             The mask will be initialized with this value.
         """
         self._roi_name = roi_name
         self._index_map = index_map
         self._default_value = default_value
+        self._multiclass = multiclass
 
     def __call__(self, sample: TileSample) -> TileSampleWithAnnotationData:
         """

--- a/dlup/data/transforms.py
+++ b/dlup/data/transforms.py
@@ -136,8 +136,9 @@ def convert_annotations(
 class ConvertAnnotationsToMask:
     """Transform which converts polygons to masks. Will overwrite the annotations key"""
 
-    def __init__(self, *, roi_name: str | None, index_map: dict[str, int], multiclass: bool = False,
-                 default_value: int = 0):
+    def __init__(
+        self, *, roi_name: str | None, index_map: dict[str, int], multiclass: bool = False, default_value: int = 0
+    ):
         """
         Converts annotations given my `dlup.annotations.Polygon` or `dlup.annotations.Point` to a mask and a dictionary
         of points. The mask is initialized with `default_value`, (i.e., background). The values in the mask are


### PR DESCRIPTION
Fixes #233 

Now, the constructor of `ConvertAnnotationsToMask` implements the multiclass flag.