### PR TITLE
Implement proper serialization of `dlup.annotations.Polygon` object to ensure correct pickling

### DIFF
--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -339,6 +339,12 @@ class Point(shapely.geometry.Point):  # type: ignore
     def __str__(self) -> str:
         return f"{self.annotation_class}, {self.wkt}"
 
+    def __reduce__(self):  # type: ignore
+        return self.__class__, (shapely.geometry.Point(self.x, self.y), self.a_cls)
+
+    def __setstate__(self, state) -> None:  # type: ignore
+        self._id_to_attrs[str(id(self))] = dict(a_cls=self.a_cls)
+
 
 class Polygon(ShapelyPolygon):  # type: ignore
     _id_to_attrs: ClassVar[dict[str, Any]] = {}

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -440,7 +440,10 @@ class Polygon(ShapelyPolygon):  # type: ignore
         return f"{self.annotation_class}, {self.wkt}"
 
     def __reduce__(self):  # type: ignore
-        return (self.__class__, (self.exterior.coords[:], self.a_cls))
+        return (
+            self.__class__,
+            (ShapelyPolygon(self.exterior.coords[:], [ring.coords[:] for ring in self.interiors]), self.a_cls),
+        )
 
     def __setstate__(self, state) -> None:  # type: ignore
         self._id_to_attrs[str(id(self))] = dict(a_cls=self.a_cls)

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -439,6 +439,12 @@ class Polygon(ShapelyPolygon):  # type: ignore
     def __str__(self) -> str:
         return f"{self.annotation_class}, {self.wkt}"
 
+    def __reduce__(self):
+        return (self.__class__, (self.exterior.coords[:], self.a_cls))
+
+    def __setstate__(self, state):
+        self._id_to_attrs[str(id(self))] = dict(a_cls=self.a_cls)
+
 
 class CoordinatesDict(TypedDict):
     type: str

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -439,10 +439,10 @@ class Polygon(ShapelyPolygon):  # type: ignore
     def __str__(self) -> str:
         return f"{self.annotation_class}, {self.wkt}"
 
-    def __reduce__(self):
+    def __reduce__(self) -> tuple[Type[Polygon], tuple[Union[tuple[float, float], ShapelyPolygon], AnnotationClass]]:
         return (self.__class__, (self.exterior.coords[:], self.a_cls))
 
-    def __setstate__(self, state):
+    def __setstate__(self, state) -> None:
         self._id_to_attrs[str(id(self))] = dict(a_cls=self.a_cls)
 
 

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -439,10 +439,10 @@ class Polygon(ShapelyPolygon):  # type: ignore
     def __str__(self) -> str:
         return f"{self.annotation_class}, {self.wkt}"
 
-    def __reduce__(self) -> tuple[Type[Polygon], tuple[Union[tuple[float, float], ShapelyPolygon], AnnotationClass]]:
+    def __reduce__(self):  # type: ignore
         return (self.__class__, (self.exterior.coords[:], self.a_cls))
 
-    def __setstate__(self, state) -> None:
+    def __setstate__(self, state) -> None:  # type: ignore
         self._id_to_attrs[str(id(self))] = dict(a_cls=self.a_cls)
 
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -182,14 +182,14 @@ class TestAnnotations:
             pickled_polygon_file.flush()
             pickled_polygon_file.seek(0)
             loaded_solid_polygon = pickle.load(pickled_polygon_file)
-        assert dlup_solid_polygon.__eq__(loaded_solid_polygon)
+        assert dlup_solid_polygon == loaded_solid_polygon
 
         with tempfile.NamedTemporaryFile(suffix=".pkl", mode="w+b") as pickled_polygon_file:
             pickle.dump(dlup_polygon_with_holes, pickled_polygon_file)
             pickled_polygon_file.flush()
             pickled_polygon_file.seek(0)
             loaded_polygon_with_holes = pickle.load(pickled_polygon_file)
-        assert dlup_polygon_with_holes.__eq__(loaded_polygon_with_holes)
+        assert dlup_polygon_with_holes == loaded_polygon_with_holes
 
     def test_point_pickling(self):
         annotation_class = AnnotationClass(label="example", annotation_type=AnnotationType.POINT, color=(255, 0, 0))
@@ -199,4 +199,4 @@ class TestAnnotations:
             pickled_point_file.flush()
             pickled_point_file.seek(0)
             loaded_point = pickle.load(pickled_point_file)
-        assert point.__eq__(loaded_point)
+        assert point == loaded_point

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -192,9 +192,7 @@ class TestAnnotations:
         assert dlup_polygon_with_holes.__eq__(loaded_polygon_with_holes)
 
     def test_point_pickling(self):
-        annotation_class = AnnotationClass(
-            label="example", annotation_type=AnnotationType.POINT, color=(255, 0, 0), z_index=1
-        )
+        annotation_class = AnnotationClass(label="example", annotation_type=AnnotationType.POINT, color=(255, 0, 0))
         point = Point((0, 0), a_cls=annotation_class)
         with tempfile.NamedTemporaryFile(suffix=".pkl", mode="w+b") as pickled_point_file:
             pickle.dump(point, pickled_point_file)

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -167,9 +167,11 @@ class TestAnnotations:
         assert [(_.area, _.annotation_type.value, _.label) for _ in region] == expected_output
 
     def test_polygon_pickling(self):
-        annotation_class = AnnotationClass(label="example", annotation_type=AnnotationType.POLYGON, color=(255, 0, 0), z_index=1)
+        annotation_class = AnnotationClass(
+            label="example", annotation_type=AnnotationType.POLYGON, color=(255, 0, 0), z_index=1
+        )
         polygon = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)], a_cls=annotation_class)
-        with tempfile.NamedTemporaryFile(suffix=".pkl", mode='w+b') as pickled_polygon_file:
+        with tempfile.NamedTemporaryFile(suffix=".pkl", mode="w+b") as pickled_polygon_file:
             pickle.dump(polygon, pickled_polygon_file)
             pickled_polygon_file.flush()
             pickled_polygon_file.seek(0)

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -3,14 +3,15 @@
 """Test the annotation facilities."""
 import json
 import pathlib
-import pickle
 import tempfile
 
 import pytest
+import pickle
 import shapely.geometry
-from shapely import Polygon as shapely_polygon
+from shapely import Point as ShapelyPoint
+from shapely import Polygon as ShapelyPolygon
 
-from dlup.annotations import AnnotationClass, AnnotationType, Point, Polygon, WsiAnnotations, shape
+from dlup.annotations import AnnotationType, Point, Polygon, WsiAnnotations, shape, AnnotationClass
 from dlup.utils.imports import DARWIN_SDK_AVAILABLE
 
 ASAP_XML_EXAMPLE = b"""<?xml version="1.0"?>
@@ -174,7 +175,7 @@ class TestAnnotations:
         exterior = [(0, 0), (4, 0), (4, 4), (0, 4)]
         hole1 = [(1, 1), (2, 1), (2, 2), (1, 2)]
         hole2 = [(3, 3), (3, 3.5), (3.5, 3.5), (3.5, 3)]
-        shapely_polygon_with_holes = shapely_polygon(exterior, [hole1, hole2])
+        shapely_polygon_with_holes = ShapelyPolygon(exterior, [hole1, hole2])
         dlup_polygon_with_holes = Polygon(shapely_polygon_with_holes, a_cls=annotation_class)
         dlup_solid_polygon = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)], a_cls=annotation_class)
         with tempfile.NamedTemporaryFile(suffix=".pkl", mode="w+b") as pickled_polygon_file:
@@ -192,11 +193,15 @@ class TestAnnotations:
         assert dlup_polygon_with_holes == loaded_polygon_with_holes
 
     def test_point_pickling(self):
-        annotation_class = AnnotationClass(label="example", annotation_type=AnnotationType.POINT, color=(255, 0, 0))
-        point = Point((0, 0), a_cls=annotation_class)
+        annotation_class = AnnotationClass(
+            label="example", annotation_type=AnnotationType.POINT, color=(255, 0, 0), z_index=None
+        )
+        coordinates = [(1, 2)]
+        shapely_point = ShapelyPoint(coordinates)
+        dlup_point = Point(shapely_point, a_cls=annotation_class)
         with tempfile.NamedTemporaryFile(suffix=".pkl", mode="w+b") as pickled_point_file:
-            pickle.dump(point, pickled_point_file)
+            pickle.dump(shapely_point, pickled_point_file)
             pickled_point_file.flush()
             pickled_point_file.seek(0)
             loaded_point = pickle.load(pickled_point_file)
-        assert point == loaded_point
+        assert dlup_point == loaded_point

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -169,8 +169,9 @@ class TestAnnotations:
     def test_polygon_pickling(self):
         annotation_class = AnnotationClass(label="example", annotation_type=AnnotationType.POLYGON, color=(255, 0, 0), z_index=1)
         polygon = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)], a_cls=annotation_class)
-        with tempfile.NamedTemporaryFile(suffix=".pkl") as pickled_polygon_file:
-            pickled_polygon_file.write(pickle.dump(polygon, pickled_polygon_file))
+        with tempfile.NamedTemporaryFile(suffix=".pkl", mode='w+b') as pickled_polygon_file:
+            pickle.dump(polygon, pickled_polygon_file)
             pickled_polygon_file.flush()
+            pickled_polygon_file.seek(0)
             loaded_polygon = pickle.load(pickled_polygon_file)
         assert polygon.__eq__(loaded_polygon)

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -3,14 +3,14 @@
 """Test the annotation facilities."""
 import json
 import pathlib
+import pickle
 import tempfile
 
 import pytest
-import pickle
 import shapely.geometry
 from shapely import Polygon as shapely_polygon
 
-from dlup.annotations import AnnotationType, Polygon, WsiAnnotations, shape, AnnotationClass
+from dlup.annotations import AnnotationClass, AnnotationType, Point, Polygon, WsiAnnotations, shape
 from dlup.utils.imports import DARWIN_SDK_AVAILABLE
 
 ASAP_XML_EXAMPLE = b"""<?xml version="1.0"?>
@@ -190,3 +190,15 @@ class TestAnnotations:
             pickled_polygon_file.seek(0)
             loaded_polygon_with_holes = pickle.load(pickled_polygon_file)
         assert dlup_polygon_with_holes.__eq__(loaded_polygon_with_holes)
+
+    def test_point_pickling(self):
+        annotation_class = AnnotationClass(
+            label="example", annotation_type=AnnotationType.POINT, color=(255, 0, 0), z_index=1
+        )
+        point = Point((0, 0), a_cls=annotation_class)
+        with tempfile.NamedTemporaryFile(suffix=".pkl", mode="w+b") as pickled_point_file:
+            pickle.dump(point, pickled_point_file)
+            pickled_point_file.flush()
+            pickled_point_file.seek(0)
+            loaded_point = pickle.load(pickled_point_file)
+        assert point.__eq__(loaded_point)

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -6,9 +6,10 @@ import pathlib
 import tempfile
 
 import pytest
+import pickle
 import shapely.geometry
 
-from dlup.annotations import AnnotationType, Polygon, WsiAnnotations, shape
+from dlup.annotations import AnnotationType, Polygon, WsiAnnotations, shape, AnnotationClass
 from dlup.utils.imports import DARWIN_SDK_AVAILABLE
 
 ASAP_XML_EXAMPLE = b"""<?xml version="1.0"?>
@@ -164,3 +165,12 @@ class TestAnnotations:
         ]
 
         assert [(_.area, _.annotation_type.value, _.label) for _ in region] == expected_output
+
+    def test_polygon_pickling(self):
+        annotation_class = AnnotationClass(label="example", annotation_type=AnnotationType.POLYGON, color=(255, 0, 0), z_index=1)
+        polygon = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)], a_cls=annotation_class)
+        with tempfile.NamedTemporaryFile(suffix=".pkl") as pickled_polygon_file:
+            pickled_polygon_file.write(pickle.dump(polygon, pickled_polygon_file))
+            pickled_polygon_file.flush()
+            loaded_polygon = pickle.load(pickled_polygon_file)
+        assert polygon.__eq__(loaded_polygon)


### PR DESCRIPTION
Fixes #235 


Refer to the issue mentioned above and check the screenshot below. While loading the pickled file, there is proper handling of the Polygon object.

![image](https://github.com/NKI-AI/dlup/assets/26798611/bdc38bdc-5043-4ae3-b12e-ede4d5da3360)
