### PR TITLE
Fix annotations not being cropped

### DIFF
--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -1095,9 +1095,7 @@ class WsiAnnotations:
 
         cropped_annotations = []
         for annotation in filtered_annotations:
-            annotation_type = annotation.annotation_class
-
-            if annotation_type in (AnnotationType.BOX, AnnotationType.POLYGON):
+            if annotation.annotation_type in (AnnotationType.BOX, AnnotationType.POLYGON):
                 _annotations = annotation.intersect_with_box(query_box)
                 if _annotations is not None:
                     cropped_annotations += _annotations

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,14 +3,14 @@ current_version = 0.5.2
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}-{release}{build}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = prod
 first_value = dev
-values = 
+values =
 	dev
 	prod
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -147,11 +147,11 @@ class TestAnnotations:
 
         region = self.v7_annotations.read_region((15300, 19000), 1.0, (2500.0, 2500.0))
         expected_output = [
-            (23552767.879399993, "BOX", "ROI (segmentation)"),
-            (2417436.551849999, "POLYGON", "stroma (area)"),
+            (6250000.0, "BOX", "ROI (segmentation)"),
+            (1616768.0657540846, "POLYGON", "stroma (area)"),
             (398284.54274999996, "POLYGON", "stroma (area)"),
             (5124.669950000004, "POLYGON", "stroma (area)"),
-            (3516247.3012999967, "POLYGON", "stroma (area)"),
+            (103262.97951705178, "POLYGON", "stroma (area)"),
             (0.0, "POINT", "lymphocyte (cell)"),
             (0.0, "POINT", "lymphocyte (cell)"),
             (0.0, "POINT", "lymphocyte (cell)"),
@@ -160,8 +160,8 @@ class TestAnnotations:
             (181.86480000002024, "BOX", "tumor (cell)"),
             (100.99830000001499, "BOX", "tumor (cell)"),
             (132.57199999999577, "BOX", "tumor (cell)"),
-            (171.38699999998718, "BOX", "tumor (cell)"),
-            (7705.718799999956, "POLYGON", "tumor (area)"),
+            (0.5479999999621504, "BOX", "tumor (cell)"),
+            (7705.718799999957, "POLYGON", "tumor (area)"),
             (10985.104649999945, "POLYGON", "tumor (area)"),
             (585.8433000000017, "BOX", "tumor (cell)"),
         ]


### PR DESCRIPTION
In 0.5.0 a new bug was introduced where the annotations were not correctly cropped. Downstream this didn't cause many issues as the masks were still correct, but the polygons had negative values. This fixes #239 