### PR TITLE
Extend dunder methods and code simplification for annotations

### DIFF
--- a/dlup/_image.py
+++ b/dlup/_image.py
@@ -26,8 +26,8 @@ from pyvips.enums import Kernel as VipsKernel
 
 from dlup._exceptions import UnsupportedSlideError
 from dlup._region import BoundaryMode, RegionView
-from dlup.backends.common import AbstractSlideBackend
 from dlup._types import GenericFloatArray, GenericIntArray, GenericNumber, GenericNumberArray, PathLike
+from dlup.backends.common import AbstractSlideBackend
 from dlup.utils.backends import ImageBackend
 from dlup.utils.image import check_if_mpp_is_valid
 

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -215,6 +215,12 @@ class AnnotatedGeometry(geometry.base.BaseGeometry):
             return False
         return True
 
+    def __iadd__(self, other):
+        raise TypeError(f"unsupported operand type(s) for +=: {type(self)} and {type(other)}")
+    
+    def __isub__(self, other):
+        raise TypeError(f"unsupported operand type(s) for -=: {type(self)} and {type(other)}")
+
 
 class Point(ShapelyPoint, AnnotatedGeometry):
     __slots__ = ShapelyPoint.__slots__
@@ -351,31 +357,6 @@ def _geometry_to_geojson(
     return data
 
 
-def _sort_layers_in_place(layers: list[Polygon | Point], sorting: AnnotationSorting | str) -> None:
-    """
-    Sorts a list of layers. Check AnnotationSorting for more information of the sorting types.
-
-
-    Parameters
-    ----------
-    layers : list[Polygon | Point]
-        All annotations belonging to a single image
-    sorting : AnnotationSorting
-        How the layers should be sorted
-
-    Returns
-    -------
-    None
-    """
-    if sorting == AnnotationSorting.Z_INDEX:
-        layers.sort(key=lambda x: (x.z_index is None, x.z_index))
-    elif sorting == AnnotationSorting.REVERSE:
-        layers.reverse()
-    elif sorting == AnnotationSorting.AREA:
-        layers.sort(key=lambda x: x.area, reverse=True)
-    # the other case is NONE, and nothing is done in that case
-
-
 class WsiAnnotations:
     """Class that holds all annotations for a specific image"""
 
@@ -384,6 +365,7 @@ class WsiAnnotations:
         layers: list[Point | Polygon],
         tags: Optional[list[AnnotationClass]] = None,
         offset_to_slide_bounds: bool = False,
+        sorting: AnnotationSorting = AnnotationSorting.NONE
     ):
         """
         Parameters
@@ -396,18 +378,24 @@ class WsiAnnotations:
             If true, will set the property `offset_to_slide_bounds` to True. This means that the annotations need
             to be offset to the slide bounds. This is useful when the annotations are read from a file format which
             requires this, for instance HaloXML.
-        """
+        sorting: AnnotationSorting
+            The sorting to apply to the annotations. Check the `AnnotationSorting` enum for more information.
+            By default, the annotations are not sorted.
 
+        """
+        self._layers = layers
+        self._tags = tags
         self._offset_to_slide_bounds = offset_to_slide_bounds
+        self._sorting = sorting
+        self._sort_layers_in_place()
+        # TODO: This can be done in one line, but this will make the tests fail
+        # self._available_classes: list[AnnotationClass] = list(set(layer.annotation_class for layer in self._layers))
         self._available_classes: list[AnnotationClass] = []
         for layer in layers:
             if layer.annotation_class in self._available_classes:
                 continue
             self._available_classes.append(layer.annotation_class)
-
-        self._layers = layers
         self._str_tree = STRtree(self._layers)
-        self._tags = tags
 
     @property
     def available_classes(self) -> list[AnnotationClass]:
@@ -428,6 +416,10 @@ class WsiAnnotations:
         bool
         """
         return self._offset_to_slide_bounds
+
+    @property
+    def sorting(self) -> bool:
+        return self._sorting
 
     def filter(self, labels: str | list[str] | tuple[str]) -> None:
         """
@@ -553,8 +545,7 @@ class WsiAnnotations:
                     _geometry = shape(x["geometry"], label=_label, color=_color, z_index=_z_index)
                     layers += _geometry
 
-        _sort_layers_in_place(layers, sorting)
-        return cls(layers=layers, tags=tags)
+        return cls(layers=layers, tags=tags, sorting=sorting)
 
     @classmethod
     def from_asap_xml(
@@ -631,8 +622,7 @@ class WsiAnnotations:
 
                     opened_annotations += 1
 
-        _sort_layers_in_place(layers, sorting)
-        return cls(layers=layers)
+        return cls(layers=layers, sorting=sorting)
 
     @classmethod
     def from_halo_xml(
@@ -683,8 +673,7 @@ class WsiAnnotations:
                     else:
                         raise NotImplementedError(f"Regiontype {region.type} is not implemented in DLUP")
 
-        _sort_layers_in_place(output_layers, sorting)
-        return cls(output_layers, offset_to_slide_bounds=True)
+        return cls(output_layers, offset_to_slide_bounds=True, sorting=sorting)
 
     @classmethod
     def from_darwin_json(
@@ -772,16 +761,25 @@ class WsiAnnotations:
             else:
                 ValueError(f"Annotation type {annotation_type} is not supported.")
 
-        _sort_layers_in_place(layers, sorting)
+        return cls(layers=layers, tags=tags, sorting=sorting)
 
-        return cls(layers=layers, tags=tags)
-
-    def __getitem__(self, idx: int) -> Point | Polygon:
-        return self._layers[idx]
-
-    def __iter__(self) -> Iterable[Point | Polygon]:
-        for layer in self._layers:
-            yield layer
+    def _sort_layers_in_place(self) -> None:
+        """
+        Sorts a list of layers. Check AnnotationSorting for more information of the sorting types.
+        Returns
+        -------
+        None
+        """
+        if self._sorting == AnnotationSorting.Z_INDEX:
+            self._layers.sort(key=lambda x: (x.z_index is None, x.z_index))
+        elif self._sorting == AnnotationSorting.REVERSE:
+            self._layers.reverse()
+        elif self._sorting == AnnotationSorting.AREA:
+            self._layers.sort(key=lambda x: x.area, reverse=True)
+        elif self._sorting == AnnotationSorting.NONE:
+            pass
+        else:
+            raise NotImplementedError(f"Sorting not implemented for {self._sorting}.")
 
     def as_geojson(self) -> GeoJsonDict:
         """
@@ -912,14 +910,85 @@ class WsiAnnotations:
         ]
         return transformed_annotations
 
-    def __add__(self, other: WsiAnnotations | Point | Polygon) -> WsiAnnotations:
-        raise NotImplementedError
+    def __str__(self) -> str:
+        return (
+            f"{type(self).__name__}(n_layers={len(self._layers)}, "
+            f"tags={[tag.label for tag in self.tags] if self.tags else None})"
+        )
 
-    def __iadd__(self, other: WsiAnnotations | Point | Polygon) -> WsiAnnotations:
-        raise NotImplementedError
+    def __contains__(self, item: Union[str, AnnotationClass, Point, Polygon]) -> bool:
+        if isinstance(item, str):
+            return item in [_.label for _ in self.available_classes]
+        elif isinstance(item, (Point, Polygon)):
+            return item in self._layers
+        return item in self.available_classes
 
-    def __radd__(self, other: WsiAnnotations) -> WsiAnnotations:
-        raise NotImplementedError
+    def __getitem__(self, idx: int) -> Point | Polygon:
+        return self._layers[idx]
+
+    def __iter__(self) -> Iterable[Point | Polygon]:
+        for layer in self._layers:
+            yield layer
+
+    def __len__(self) -> int:
+        return len(self._layers)
+
+    def __add__(self, other: WsiAnnotations | Point | Polygon | list[Point | Polygon]) -> WsiAnnotations:
+        if isinstance(other, (Point, Polygon)):
+            other = [other]
+
+        if isinstance(other, list):
+            if not all(isinstance(item, (Point, Polygon)) for item in other):
+                raise TypeError("")
+            new_layers = self._layers + other
+            new_tags = self.tags
+        elif isinstance(other, WsiAnnotations):
+            if self.sorting != other.sorting or self.offset_to_slide_bounds != other.offset_to_slide_bounds:
+                raise ValueError("")
+            new_layers = self._layers + other._layers
+            new_tags = self.tags if self.tags is not None else [] + other.tags if other.tags is not None else None
+        else:
+            return NotImplemented
+        return WsiAnnotations(
+            layers=new_layers, tags=new_tags, offset_to_slide_bounds=self.offset_to_slide_bounds, sorting=self.sorting
+        )
+
+    def __iadd__(self, other: WsiAnnotations | Point | Polygon | list[Point | Polygon]) -> WsiAnnotations:
+        if isinstance(other, (Point, Polygon)):
+            other = [other]
+
+        if isinstance(other, list):
+            if not all(isinstance(item, (Point, Polygon)) for item in other):
+                raise TypeError("")
+
+            self._layers += other
+            for item in other:
+                if item.annotation_class not in self:
+                    self._available_classes.append(item.annotation_class)
+        elif isinstance(other, WsiAnnotations):
+            if self.sorting != other.sorting or self.offset_to_slide_bounds != other.offset_to_slide_bounds:
+                raise ValueError("")
+            self._layers += other._layers
+
+            if self.tags is None:
+                self._tags = other._tags
+            elif other.tags is not None:
+                self._tags += other._tags
+
+            for available_class in other.available_classes:
+                if available_class not in self:
+                    self._available_classes.append(available_class)
+        else:
+            return NotImplemented
+        self._sort_layers_in_place()
+        self._str_tree = STRtree(self._layers)
+        return self
+    
+    def __radd__(self, other: WsiAnnotations | Point | Polygon) -> WsiAnnotations:
+        # in-place addition (+=) of Point and Polygon will raise a TypeError
+        if not isinstance(other, (WsiAnnotations, Point, Polygon)):
+            return NotImplemented
+        return self + other
 
     def __sub__(self, other: WsiAnnotations | Point | Polygon) -> WsiAnnotations:
         raise NotImplementedError
@@ -929,17 +998,6 @@ class WsiAnnotations:
 
     def __rsub__(self, other: WsiAnnotations) -> WsiAnnotations:
         raise NotImplementedError
-
-    def __contains__(self, item: Union[str, AnnotationClass]) -> bool:
-        if isinstance(item, str):
-            return item in [_.label for _ in self.available_classes]
-        return item in self.available_classes
-
-    def __str__(self) -> str:
-        return (
-            f"{type(self).__name__}(n_layers={len(self._layers)}, "
-            f"tags={[tag.label for tag in self.tags] if self.tags else None})"
-        )
 
 
 class _ComplexDarwinPolygonWrapper:

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -17,14 +17,13 @@ from __future__ import annotations
 
 import copy
 import errno
-import functools
 import json
 import os
 import pathlib
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass, replace
 from enum import Enum
-from typing import Any, ClassVar, Iterable, NamedTuple, Optional, Type, TypedDict, TypeVar, Union, cast
+from typing import Any, ClassVar, Iterable, Optional, Type, TypedDict, TypeVar, Union, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -41,7 +40,12 @@ from shapely.validation import make_valid
 
 from dlup._exceptions import AnnotationError
 from dlup._types import GenericNumber, PathLike
-from dlup.utils.annotations_utils import _hex_to_rgb, _get_geojson_color, _get_geojson_z_index
+from dlup.utils.annotations_utils import (
+    _get_geojson_color,
+    _get_geojson_z_index,
+    _get_v7_metadata,
+    _hex_to_rgb,
+)
 from dlup.utils.imports import DARWIN_SDK_AVAILABLE, PYHALOXML_AVAILABLE
 
 # TODO:
@@ -52,12 +56,6 @@ from dlup.utils.imports import DARWIN_SDK_AVAILABLE, PYHALOXML_AVAILABLE
 
 _TWsiAnnotations = TypeVar("_TWsiAnnotations", bound="WsiAnnotations")
 ShapelyTypes = Union[ShapelyPoint, ShapelyMultiPolygon, ShapelyPolygon]
-
-
-class DarwinV7Metadata(NamedTuple):
-    label: str
-    color: tuple[int, int, int]
-    type: AnnotationType
 
 
 class AnnotationType(str, Enum):
@@ -145,37 +143,6 @@ class AnnotationClass:
             raise ValueError("z_index is not supported for point annotations or tags.")
 
 
-@functools.lru_cache(maxsize=None)
-def _get_v7_metadata(filename: pathlib.Path) -> Optional[dict[str, DarwinV7Metadata]]:
-    if not DARWIN_SDK_AVAILABLE:
-        raise RuntimeError("`darwin` is not available. Install using `python -m pip install darwin-py`.")
-    import darwin.path_utils
-
-    if not filename.is_dir():
-        raise RuntimeError("Provide the path to the root folder of the Darwin V7 annotations")
-
-    v7_metadata_fn = filename / ".v7" / "metadata.json"
-    if not v7_metadata_fn.exists():
-        return None
-    v7_metadata = darwin.path_utils.parse_metadata(v7_metadata_fn)
-    output = {}
-    for sample in v7_metadata["classes"]:
-        annotation_type = AnnotationTypeToDLUPAnnotationType.from_string(sample["type"])
-        # This is not implemented and can be skipped. The main function will raise a NonImplementedError
-        if annotation_type == AnnotationType.RASTER:
-            continue
-
-        label = sample["name"]
-        color = sample["color"][5:-1].split(",")
-        if color[-1] != "1.0":
-            raise RuntimeError("Expected A-channel of color to be 1.0")
-        rgb_colors = (int(color[0]), int(color[1]), int(color[2]))
-
-        output[label] = DarwinV7Metadata(label=label, color=rgb_colors, type=annotation_type)
-
-    return output
-
-
 def _is_rectangle(polygon: Polygon | ShapelyPolygon) -> tuple[bool, bool]:
     if not polygon.is_valid or len(polygon.exterior.coords) != 5 or len(polygon.interiors) != 0:
         return False, False
@@ -193,7 +160,7 @@ class GeoJsonDict(TypedDict):
     type: str
     features: list[dict[str, str | dict[str, str]]]
     metadata: Optional[dict[str, str | list[str]]]
-
+    
 
 class AnnotatedGeometry(geometry.base.BaseGeometry):
     __slots__ = geometry.base.BaseGeometry.__slots__
@@ -762,13 +729,12 @@ class WsiAnnotations:
         layers = []
         for curr_annotation in darwin_an.annotations:
             name = curr_annotation.annotation_class.name
-            annotation_type = AnnotationTypeToDLUPAnnotationType.from_string(
-                curr_annotation.annotation_class.annotation_type
-            )
+            darwin_annotation_type = curr_annotation.annotation_class.annotation_type
+            annotation_type = AnnotationTypeToDLUPAnnotationType.from_string(darwin_annotation_type)
             if annotation_type == AnnotationType.RASTER:
                 raise NotImplementedError("Raster annotations are not supported.")
 
-            annotation_color = v7_metadata[name].color if v7_metadata else None
+            annotation_color = v7_metadata[(name, darwin_annotation_type)].color if v7_metadata else None
 
             if annotation_type == AnnotationType.TAG:
                 tags.append(

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -994,6 +994,24 @@ class WsiAnnotations:
                 cropped_annotations.append(annotation)
         return cropped_annotations
 
+    def __add__(self, other: WsiAnnotations | Point | Polygon) -> WsiAnnotations:
+        raise NotImplementedError
+
+    def __iadd__(self, other: WsiAnnotations | Point | Polygon) -> WsiAnnotations:
+        raise NotImplementedError
+
+    def __radd__(self, other: WsiAnnotations) -> WsiAnnotations:
+        raise NotImplementedError
+    
+    def __sub__(self, other: WsiAnnotations | Point | Polygon) -> WsiAnnotations:
+        raise NotImplementedError
+
+    def __isub__(self, other: WsiAnnotations | Point | Polygon) -> WsiAnnotations:
+        raise NotImplementedError
+
+    def __rsub__(self, other: WsiAnnotations) -> WsiAnnotations:
+        raise NotImplementedError
+
     def __contains__(self, item: Union[str, AnnotationClass]) -> bool:
         if isinstance(item, str):
             return item in [_.label for _ in self.available_classes]

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -103,7 +103,7 @@ class AnnotationSorting(str, Enum):
 class AnnotationClass:
     """An annotation class. An annotation has two required properties:
     - label: The name of the annotation, e.g., "lymphocyte".
-    - a_cls: The type of annotation, e.g., AnnotationType.POINT.
+    - annotation_type: The type of annotation, e.g., AnnotationType.POINT.
 
     And two optional properties:
     - color: The color of the annotation as a tuple of RGB values.
@@ -1039,7 +1039,7 @@ class WsiAnnotations:
                 curr_annotation,
                 label=curr_annotation.label,
                 color=curr_annotation.color,
-                z_index=curr_annotation.z_index,
+                z_index=curr_annotation.z_index if isinstance(curr_annotation, Polygon) else None,
             )
             json_dict["id"] = str(idx)
             data["features"].append(json_dict)

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -160,7 +160,7 @@ class GeoJsonDict(TypedDict):
     type: str
     features: list[dict[str, str | dict[str, str]]]
     metadata: Optional[dict[str, str | list[str]]]
-    
+
 
 class AnnotatedGeometry(geometry.base.BaseGeometry):
     __slots__ = geometry.base.BaseGeometry.__slots__
@@ -244,7 +244,7 @@ class Polygon(ShapelyPolygon, AnnotatedGeometry):
         return cast("Polygon", instance)
 
     def intersect_with_box(
-        self, other: ShapelyPolygon, affine_transform_matrix: list[float]
+        self, other: ShapelyPolygon,
     ) -> Optional[list["Polygon"]]:
         result = make_valid(self).intersection(other)
         if self.area > 0 and result.area == 0:
@@ -256,11 +256,10 @@ class Polygon(ShapelyPolygon, AnnotatedGeometry):
         else:
             annotation_class = self.annotation_class
 
-        transformed_results = shapely.affinity.affine_transform(result, affine_transform_matrix)
-        if isinstance(transformed_results, ShapelyPolygon):
-            return [Polygon(transformed_results, a_cls=annotation_class)]
-        elif isinstance(transformed_results, (ShapelyMultiPolygon, shapely.geometry.collection.GeometryCollection)):
-            return [Polygon(geom, a_cls=annotation_class) for geom in transformed_results.geoms if geom.area > 0]
+        if isinstance(result, ShapelyPolygon):
+            return [Polygon(result, a_cls=annotation_class)]
+        elif isinstance(result, (ShapelyMultiPolygon, shapely.geometry.collection.GeometryCollection)):
+            return [Polygon(geom, a_cls=annotation_class) for geom in result.geoms if geom.area > 0]
         else:
             raise NotImplementedError(f"{type(result)}")
 
@@ -895,20 +894,22 @@ class WsiAnnotations:
         curr_indices.sort()
         filtered_annotations: list[Point | Polygon] = self._str_tree.geometries.take(curr_indices).tolist()
 
-        cropped_annotations = []
-        affine_transform_matrix = [scaling, 0, 0, scaling, -location[0], -location[1]]
+        cropped_annotations: list[Point | Polygon] = []
         for annotation in filtered_annotations:
             if annotation.annotation_type in (AnnotationType.BOX, AnnotationType.POLYGON):
-                _annotations = annotation.intersect_with_box(query_box, affine_transform_matrix=affine_transform_matrix)
+                _annotations = annotation.intersect_with_box(query_box)
                 if _annotations is not None:
                     cropped_annotations += _annotations
-            elif annotation.annotation_type == AnnotationType.POINT:
-                _annotation = shapely.affinity.affine_transform(annotation, affine_transform_matrix)
-                cropped_annotations.append(Point(_annotation, a_cls=annotation.annotation_class))
             # Tags could end up here in theory?
             else:
                 cropped_annotations.append(annotation)
-        return cropped_annotations
+
+        affine_matrix = [scaling, 0, 0, scaling, -location[0], -location[1]]
+        transformed_annotations = [
+            type(_ann)(shapely.affinity.affine_transform(_ann, affine_matrix), a_cls=_ann.annotation_class)
+            for _ann in cropped_annotations
+        ]
+        return transformed_annotations
 
     def __add__(self, other: WsiAnnotations | Point | Polygon) -> WsiAnnotations:
         raise NotImplementedError

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -254,7 +254,7 @@ class AnnotatedGeometry(geometry.base.BaseGeometry):  # type: ignore[misc]
         if not isinstance(other, type(self)):
             return False
 
-        if not other.annotation_class == self.annotation_class:
+        if other.annotation_class != self.annotation_class:
             return False
         return True
 
@@ -1034,51 +1034,45 @@ class WsiAnnotations:
         raise NotImplementedError
 
 
-class _ComplexDarwinPolygonWrapper:
-    """Wrapper class for a complex polygon (i.e. polygon with holes) from a Darwin annotation."""
-
-    def __init__(self, polygon: ShapelyPolygon):
-        self.geom = polygon
-        self.hole = False
-        self.holes: list[float] = []
-
-
 def _parse_darwin_complex_polygon(annotation: dict[str, Any]) -> ShapelyMultiPolygon:
     """
     Parse a complex polygon (i.e. polygon with holes) from a Darwin annotation.
-
     Parameters
     ----------
     annotation : dict
-
     Returns
     -------
     ShapelyMultiPolygon
     """
-    polygons = [
-        _ComplexDarwinPolygonWrapper(ShapelyPolygon([(p["x"], p["y"]) for p in path])) for path in annotation["paths"]
-    ]
-
-    # Naive even-odd rule, but seems to work
-    sorted_polygons = sorted(polygons, key=lambda x: x.geom.area, reverse=True)
-    for idx, my_polygon in enumerate(sorted_polygons):
-        for outer_polygon in reversed(sorted_polygons[:idx]):
-            contains = outer_polygon.geom.contains(my_polygon.geom)
-            if contains and outer_polygon.hole:
+    # Create Polygons and sort by area in descending order
+    polygons: list[ShapelyPolygon] = sorted(
+        [ShapelyPolygon([(p["x"], p["y"]) for p in path]) for path in annotation["paths"]],
+        key=lambda x: x.area,
+        reverse=True,
+    )
+    outer_polygons: list[tuple[ShapelyPolygon, list[ShapelyPolygon], bool]] = []
+    for polygon in polygons:
+        is_hole = False
+        # Check if the polygon can be a hole in any of the previously processed polygons
+        for outer_poly, holes, outer_poly_is_hole in reversed(outer_polygons):
+            contains = outer_poly.contains(polygon)
+            # If polygon is contained by a hole, it should be added as new polygon
+            if contains and outer_poly_is_hole:
                 break
-            if outer_polygon.hole:
-                continue
-            if contains:
-                my_polygon.hole = True
-                outer_polygon.holes.append(my_polygon.geom.exterior.coords)
+            # Polygon is added as hole if outer polygon is not a hole
+            elif contains:
+                holes.append(polygon.exterior.coords)
+                is_hole = True
+                break
+        outer_polygons.append((polygon, [], is_hole))
 
-    # create complex polygon with MultiPolygon
-    complex_polygon = [
-        ShapelyPolygon(my_polygon.geom.exterior.coords, my_polygon.holes)
-        for my_polygon in sorted_polygons
-        if not my_polygon.hole
-    ]
-    return ShapelyMultiPolygon(complex_polygon)
+    return ShapelyMultiPolygon(
+        [
+            ShapelyPolygon(outer_poly.exterior.coords, holes)
+            for outer_poly, holes, _is_hole in outer_polygons
+            if not _is_hole
+        ]
+    )
 
 
 def _parse_asap_coordinates(

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -935,7 +935,6 @@ class WsiAnnotations:
                 _annotations = annotation.intersect_with_box(query_box)
                 if _annotations is not None:
                     cropped_annotations += _annotations
-            # Tags could end up here in theory?
             else:
                 cropped_annotations.append(annotation)
 
@@ -1025,13 +1024,13 @@ class WsiAnnotations:
         return self + other
 
     def __sub__(self, other: WsiAnnotations | Point | Polygon) -> WsiAnnotations:
-        raise NotImplementedError
+        return NotImplemented
 
     def __isub__(self, other: WsiAnnotations | Point | Polygon) -> WsiAnnotations:
-        raise NotImplementedError
+        return NotImplemented
 
     def __rsub__(self, other: WsiAnnotations) -> WsiAnnotations:
-        raise NotImplementedError
+        return NotImplemented
 
 
 def _parse_darwin_complex_polygon(annotation: dict[str, Any]) -> ShapelyMultiPolygon:

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -41,6 +41,7 @@ from shapely.validation import make_valid
 
 from dlup._exceptions import AnnotationError
 from dlup._types import GenericNumber, PathLike
+from dlup.utils.annotations_utils import _hex_to_rgb, _get_geojson_color, _get_geojson_z_index
 from dlup.utils.imports import DARWIN_SDK_AVAILABLE, PYHALOXML_AVAILABLE
 
 # TODO:
@@ -59,25 +60,33 @@ class DarwinV7Metadata(NamedTuple):
     type: AnnotationType
 
 
-def _hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
-    if "#" not in hex_color:
-        if hex_color == "black":
-            return 0, 0, 0
-    hex_color = hex_color.lstrip("#")
-
-    # Convert the string from hex to an integer and extract each color component
-    r = int(hex_color[0:2], 16)
-    g = int(hex_color[2:4], 16)
-    b = int(hex_color[4:6], 16)
-    return r, g, b
-
-
 class AnnotationType(str, Enum):
     POINT = "POINT"
     BOX = "BOX"
     POLYGON = "POLYGON"
     TAG = "TAG"
     RASTER = "RASTER"
+
+class AnnotationTypeToDLUPAnnotationType(Enum):
+    # Shared annotation types
+    polygon = AnnotationType.POLYGON
+    # ASAP annotation types
+    rectangle = AnnotationType.BOX
+    dot = AnnotationType.POINT
+    spline = AnnotationType.POLYGON
+    pointset = AnnotationType.POINT
+    # Darwin V7 annotation types
+    bounding_box = AnnotationType.BOX
+    complex_polygon = AnnotationType.POLYGON
+    keypoint = AnnotationType.POINT
+    tag = AnnotationType.TAG
+
+    @classmethod
+    def from_string(cls, annotation_type: str) -> AnnotationType:
+        try:
+            return cls[annotation_type].value
+        except KeyError:
+            raise NotImplementedError(f"annotation_type {annotation_type} is not implemented or not a valid dlup type.")
 
 
 class AnnotationSorting(str, Enum):
@@ -151,7 +160,7 @@ def _get_v7_metadata(filename: pathlib.Path) -> Optional[dict[str, DarwinV7Metad
     v7_metadata = darwin.path_utils.parse_metadata(v7_metadata_fn)
     output = {}
     for sample in v7_metadata["classes"]:
-        annotation_type = _v7_annotation_type_to_dlup_annotation_type(sample["type"])
+        annotation_type = AnnotationTypeToDLUPAnnotationType.from_string(sample["type"])
         # This is not implemented and can be skipped. The main function will raise a NonImplementedError
         if annotation_type == AnnotationType.RASTER:
             continue
@@ -165,54 +174,6 @@ def _get_v7_metadata(filename: pathlib.Path) -> Optional[dict[str, DarwinV7Metad
         output[label] = DarwinV7Metadata(label=label, color=rgb_colors, type=annotation_type)
 
     return output
-
-
-_ASAP_TYPES = {
-    "polygon": AnnotationType.POLYGON,
-    "rectangle": AnnotationType.BOX,
-    "dot": AnnotationType.POINT,
-    "spline": AnnotationType.POLYGON,
-    "pointset": AnnotationType.POINT,
-}
-
-
-def _get_geojson_color(properties: dict[str, str | list[int]]) -> Optional[tuple[int, int, int]]:
-    """Parse the properties dictionary of a GeoJSON object to get the color.
-
-    Arguments
-    ---------
-    properties : dict
-        The properties dictionary of a GeoJSON object.
-
-    Returns
-    -------
-    Optional[tuple[int, int, int]]
-        The color of the object as a tuple of RGB values.
-    """
-    color = properties.get("color", None)
-    if color is None:
-        return None
-
-    return cast(tuple[int, int, int], tuple(color))
-
-def _get_geojson_z_index(properties: dict[str, str | list[int]]) -> Optional[int]:
-    """Parse the properties dictionary of a GeoJSON object to get the z_index`.
-
-    Arguments
-    ---------
-    properties : dict
-        The properties dictionary of a GeoJSON object.
-
-    Returns
-    -------
-    Optional[tuple[int, int, int]]
-        The color of the object as a tuple of RGB values.
-    """
-    z_index = properties.get("z_index", None)
-    if z_index is None:
-        return None
-
-    return cast(int, z_index)
 
 
 def _is_rectangle(polygon: Polygon | ShapelyPolygon) -> tuple[bool, bool]:
@@ -299,7 +260,7 @@ class Point(ShapelyPoint, AnnotatedGeometry):
         return cast("Point", point)
 
     def __reduce__(self):  # type: ignore
-        return (self.__class__, (ShapelyPoint(self.xy), self.annotation_class))
+        return (self.__class__, (self.xy, self.annotation_class))
 
 
 class Polygon(ShapelyPolygon, AnnotatedGeometry):
@@ -329,7 +290,6 @@ class Polygon(ShapelyPolygon, AnnotatedGeometry):
             annotation_class = self.annotation_class
 
         transformed_results = shapely.affinity.affine_transform(result, affine_transform_matrix)
-        # FIXME: Can we even have MultiPolygons at this stage?
         if isinstance(transformed_results, ShapelyPolygon):
             return [Polygon(transformed_results, a_cls=annotation_class)]
         elif isinstance(transformed_results, (ShapelyMultiPolygon, shapely.geometry.collection.GeometryCollection)):
@@ -368,28 +328,19 @@ def shape(
             Point(np.asarray(c), a_cls=annotation_class)
             for c in (_coordinates if geom_type == "multipoint" else [_coordinates])
         ]
-
-    if geom_type == "polygon":
+    elif geom_type in ["polygon", "multipolygon"]:
         _coordinates = coordinates["coordinates"]
-        annotation_type = AnnotationType.BOX if _is_rectangle(Polygon(_coordinates[0]))[0] else AnnotationType.POLYGON
+        # TODO: Give every polygon in multipolygon their own annotation_class / annotation_type
+        annotation_type = (
+            AnnotationType.BOX
+            if geom_type == "polygon" and _is_rectangle(Polygon(_coordinates[0]))[0]
+            else AnnotationType.POLYGON
+        )
         annotation_class = AnnotationClass(label=label, annotation_type=annotation_type, color=color, z_index=z_index)
-        return [Polygon(shell=np.asarray(_coordinates[0]), holes=[np.asarray(hole) for hole in _coordinates[1:]], a_cls=annotation_class)]
-    if geom_type == "multipolygon":
-        annotation_class = AnnotationClass(
-            label=label, annotation_type=AnnotationType.POLYGON, color=color, z_index=z_index
-        )
-        # the first element is the outer polygon, the rest are holes.
-        # TODO: This needs to work by directly constructing it with an a_cls
-        multi_polygon = ShapelyMultiPolygon(
-            [
-                [
-                    np.asarray(c[0]),
-                    [np.asarray(hole) for hole in c[1:]],
-                ]
-                for c in coordinates["coordinates"]
-            ]
-        )
-        return [Polygon(_, a_cls=annotation_class) for _ in multi_polygon.geoms]
+        return [
+            Polygon(shell=np.asarray(c[0]), holes=[np.asarray(hole) for hole in c[1:]], a_cls=annotation_class)
+            for c in (_coordinates if geom_type == "multipolygon" else [_coordinates])
+        ]
 
     raise AnnotationError(f"Unsupported geom_type {geom_type}")
 
@@ -679,7 +630,7 @@ class WsiAnnotations:
                 color = _hex_to_rgb(child.attrib.get("Color").strip())  # type: ignore
 
                 _type = child.attrib.get("Type").lower()  # type: ignore
-                annotation_type = _ASAP_TYPES[_type]
+                annotation_type = AnnotationTypeToDLUPAnnotationType.from_string(_type)
                 coordinates = _parse_asap_coordinates(child, annotation_type, scaling=scaling)
 
                 if not coordinates.is_valid:
@@ -811,8 +762,7 @@ class WsiAnnotations:
         layers = []
         for curr_annotation in darwin_an.annotations:
             name = curr_annotation.annotation_class.name
-
-            annotation_type = _v7_annotation_type_to_dlup_annotation_type(
+            annotation_type = AnnotationTypeToDLUPAnnotationType.from_string(
                 curr_annotation.annotation_class.annotation_type
             )
             if annotation_type == AnnotationType.RASTER:
@@ -1002,7 +952,7 @@ class WsiAnnotations:
 
     def __radd__(self, other: WsiAnnotations) -> WsiAnnotations:
         raise NotImplementedError
-    
+
     def __sub__(self, other: WsiAnnotations | Point | Polygon) -> WsiAnnotations:
         raise NotImplementedError
 
@@ -1114,34 +1064,3 @@ def _parse_asap_coordinates(
         raise AnnotationError(f"Annotation type not supported. Got {annotation_type}.")
 
     return coordinates
-
-
-def _v7_annotation_type_to_dlup_annotation_type(annotation_type: str) -> AnnotationType:
-    """
-    Convert a v7 annotation type to a dlup annotation type.
-
-    Parameters
-    ----------
-    annotation_type : str
-        The annotation type as defined in the v7 annotation format.
-
-    Returns
-    -------
-    AnnotationType
-    """
-    if annotation_type == "bounding_box":
-        return AnnotationType.BOX
-
-    if annotation_type in ["polygon", "complex_polygon"]:
-        return AnnotationType.POLYGON
-
-    if annotation_type == "keypoint":
-        return AnnotationType.POINT
-
-    if annotation_type == "tag":
-        return AnnotationType.TAG
-
-    if annotation_type == "raster_layer":
-        return AnnotationType.RASTER
-
-    raise NotImplementedError(f"annotation_type {annotation_type} is not implemented or not a valid dlup type.")

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -40,12 +40,7 @@ from shapely.validation import make_valid
 
 from dlup._exceptions import AnnotationError
 from dlup._types import GenericNumber, PathLike
-from dlup.utils.annotations_utils import (
-    _get_geojson_color,
-    _get_geojson_z_index,
-    _get_v7_metadata,
-    _hex_to_rgb,
-)
+from dlup.utils.annotations_utils import _get_geojson_color, _get_geojson_z_index, _get_v7_metadata, _hex_to_rgb
 from dlup.utils.imports import DARWIN_SDK_AVAILABLE, PYHALOXML_AVAILABLE
 
 # TODO:
@@ -64,6 +59,7 @@ class AnnotationType(str, Enum):
     POLYGON = "POLYGON"
     TAG = "TAG"
     RASTER = "RASTER"
+
 
 class AnnotationTypeToDLUPAnnotationType(Enum):
     # Shared annotation types
@@ -84,7 +80,9 @@ class AnnotationTypeToDLUPAnnotationType(Enum):
         try:
             return cls[annotation_type].value
         except KeyError:
-            raise NotImplementedError(f"annotation_type {annotation_type} is not implemented or not a valid dlup type.")
+            raise NotImplementedError(
+                f"annotation_type {annotation_type} is not implemented or not a valid dlup type."
+            )
 
 
 class AnnotationSorting(str, Enum):
@@ -143,12 +141,18 @@ class AnnotationClass:
             raise ValueError("z_index is not supported for point annotations or tags.")
 
 
-def _is_rectangle(polygon: Polygon | ShapelyPolygon) -> tuple[bool, bool]:
+def _is_rectangle(polygon: Polygon | ShapelyPolygon) -> bool:
     if not polygon.is_valid or len(polygon.exterior.coords) != 5 or len(polygon.interiors) != 0:
-        return False, False
+        return False
+    return bool(np.isclose(polygon.area, polygon.minimum_rotated_rectangle.area))
+
+
+def _is_alligned_rectangle(polygon: Polygon | ShapelyPolygon) -> bool:
+    if not _is_rectangle(polygon):
+        return False
     min_rotated_rect = polygon.minimum_rotated_rectangle
     aligned_rect = min_rotated_rect.minimum_rotated_rectangle
-    return (np.isclose(polygon.area, min_rotated_rect.area), min_rotated_rect == aligned_rect)
+    return bool(min_rotated_rect == aligned_rect)
 
 
 class GeoJsonDict(TypedDict):
@@ -162,7 +166,7 @@ class GeoJsonDict(TypedDict):
     metadata: Optional[dict[str, str | list[str]]]
 
 
-class AnnotatedGeometry(geometry.base.BaseGeometry):
+class AnnotatedGeometry(geometry.base.BaseGeometry):  # type: ignore[misc]
     __slots__ = geometry.base.BaseGeometry.__slots__
     _a_cls: ClassVar[dict[str, Any]] = {}
 
@@ -173,11 +177,11 @@ class AnnotatedGeometry(geometry.base.BaseGeometry):
     ) -> None:
         # Get annotation_class from args and kwargs. We do this because the __new__ method takes different (kw)args
         a_cls = next((arg for arg in args if isinstance(arg, AnnotationClass)), kwargs.get("a_cls", None))
-        self._a_cls[id(self)] = a_cls
+        self._a_cls[str(id(self))] = a_cls
 
     @property
     def annotation_class(self) -> AnnotationClass:
-        return cast(AnnotationClass, self._a_cls[id(self)])
+        return cast(AnnotationClass, self._a_cls[str(id(self))])
 
     @property
     def annotation_type(self) -> AnnotationType | str:
@@ -196,8 +200,8 @@ class AnnotatedGeometry(geometry.base.BaseGeometry):
         return self.annotation_class.z_index
 
     def __del__(self) -> None:
-        if id(self) in self._a_cls:
-            del self._a_cls[id(self)]
+        if str(id(self)) in self._a_cls:
+            del self._a_cls[str(id(self))]
 
     def __str__(self) -> str:
         return f"{self.annotation_class}, {self.wkt}"
@@ -207,7 +211,6 @@ class AnnotatedGeometry(geometry.base.BaseGeometry):
         if not geometry_equal:
             return False
 
-        # TODO: Check evaluation with ShapelyPolygon / ShapelyPoint. Does it evaluate to True?
         if not isinstance(other, type(self)):
             return False
 
@@ -215,34 +218,32 @@ class AnnotatedGeometry(geometry.base.BaseGeometry):
             return False
         return True
 
-    def __iadd__(self, other):
+    def __iadd__(self, other: Any) -> None:
         raise TypeError(f"unsupported operand type(s) for +=: {type(self)} and {type(other)}")
-    
-    def __isub__(self, other):
+
+    def __isub__(self, other: Any) -> None:
         raise TypeError(f"unsupported operand type(s) for -=: {type(self)} and {type(other)}")
 
 
-class Point(ShapelyPoint, AnnotatedGeometry):
+class Point(ShapelyPoint, AnnotatedGeometry):  # type: ignore[misc]
     __slots__ = ShapelyPoint.__slots__
 
-    def __new__(
-        cls, coord: ShapelyPoint | tuple[float, float], a_cls: AnnotationClass = None
-    ) -> "Point":
+    def __new__(cls, coord: ShapelyPoint | tuple[float, float], a_cls: Optional[AnnotationClass] = None) -> "Point":
         point = super().__new__(cls, coord)
         point.__class__ = cls
         return cast("Point", point)
 
-    def __reduce__(self):  # type: ignore
-        return (self.__class__, (self.xy, self.annotation_class))
+    def __reduce__(self) -> tuple[type, tuple[tuple[float, float], Optional[AnnotationClass]]]:
+        return (self.__class__, ((self.x, self.y), self.annotation_class))
 
 
-class Polygon(ShapelyPolygon, AnnotatedGeometry):
+class Polygon(ShapelyPolygon, AnnotatedGeometry):  # type: ignore[misc]
     __slots__ = ShapelyPolygon.__slots__
 
     def __new__(
         cls,
         shell: Union[tuple[float, float], ShapelyPolygon],
-        holes: Optional[list[list[float, float]]] = None,
+        holes: Optional[list[list[list[float]]] | list[npt.NDArray[np.float_]]] = None,
         a_cls: Optional[AnnotationClass] = None,
     ) -> "Polygon":
         instance = super().__new__(cls, shell, holes)
@@ -250,14 +251,15 @@ class Polygon(ShapelyPolygon, AnnotatedGeometry):
         return cast("Polygon", instance)
 
     def intersect_with_box(
-        self, other: ShapelyPolygon,
+        self,
+        other: ShapelyPolygon,
     ) -> Optional[list["Polygon"]]:
         result = make_valid(self).intersection(other)
         if self.area > 0 and result.area == 0:
             return None
 
         # Verify if this box is still a box. Create annotation_type to polygon if that is not the case
-        if self.annotation_type == AnnotationType.BOX and not _is_rectangle(result)[0]:
+        if self.annotation_type == AnnotationType.BOX and not _is_rectangle(result):
             annotation_class = replace(self.annotation_class, annotation_type=AnnotationType.POLYGON)
         else:
             annotation_class = self.annotation_class
@@ -269,15 +271,19 @@ class Polygon(ShapelyPolygon, AnnotatedGeometry):
         else:
             raise NotImplementedError(f"{type(result)}")
 
-    def __reduce__(self):  # type: ignore
+    def __reduce__(
+        self,
+    ) -> tuple[type, tuple[list[tuple[float, float]], list[list[tuple[float, float]]], Optional[AnnotationClass]]]:
         return (
             self.__class__,
             (self.exterior.coords[:], [ring.coords[:] for ring in self.interiors], self.annotation_class),
         )
 
+
 class CoordinatesDict(TypedDict):
     type: str
-    coordinates: list[list[list[float]]]
+    coordinates: list[list[list[float]]] | list[list[tuple[float, float]]]
+
 
 def shape(
     coordinates: CoordinatesDict,
@@ -305,7 +311,7 @@ def shape(
         # TODO: Give every polygon in multipolygon their own annotation_class / annotation_type
         annotation_type = (
             AnnotationType.BOX
-            if geom_type == "polygon" and _is_rectangle(Polygon(_coordinates[0]))[0]
+            if geom_type == "polygon" and _is_rectangle(Polygon(_coordinates[0]))
             else AnnotationType.POLYGON
         )
         annotation_class = AnnotationClass(label=label, annotation_type=annotation_type, color=color, z_index=z_index)
@@ -365,7 +371,7 @@ class WsiAnnotations:
         layers: list[Point | Polygon],
         tags: Optional[list[AnnotationClass]] = None,
         offset_to_slide_bounds: bool = False,
-        sorting: AnnotationSorting = AnnotationSorting.NONE
+        sorting: AnnotationSorting | str = AnnotationSorting.NONE,
     ):
         """
         Parameters
@@ -388,17 +394,11 @@ class WsiAnnotations:
         self._offset_to_slide_bounds = offset_to_slide_bounds
         self._sorting = sorting
         self._sort_layers_in_place()
-        # TODO: This can be done in one line, but this will make the tests fail
-        # self._available_classes: list[AnnotationClass] = list(set(layer.annotation_class for layer in self._layers))
-        self._available_classes: list[AnnotationClass] = []
-        for layer in layers:
-            if layer.annotation_class in self._available_classes:
-                continue
-            self._available_classes.append(layer.annotation_class)
+        self._available_classes: set[AnnotationClass] = {layer.annotation_class for layer in self._layers}
         self._str_tree = STRtree(self._layers)
 
     @property
-    def available_classes(self) -> list[AnnotationClass]:
+    def available_classes(self) -> set[AnnotationClass]:
         return self._available_classes
 
     @property
@@ -418,7 +418,7 @@ class WsiAnnotations:
         return self._offset_to_slide_bounds
 
     @property
-    def sorting(self) -> bool:
+    def sorting(self) -> AnnotationSorting | str:
         return self._sorting
 
     def filter(self, labels: str | list[str] | tuple[str]) -> None:
@@ -435,16 +435,9 @@ class WsiAnnotations:
         -------
         None
         """
-        new_available_classes: list[AnnotationClass] = []
-        new_layers: list[Point | Polygon] = []
         _labels = [labels] if isinstance(labels, str) else labels
-        for layer in self._layers:
-            if layer.label in _labels:
-                new_available_classes += [layer.annotation_class]
-                new_layers += [layer]
-
-        self._available_classes = new_available_classes
-        self._layers = new_layers
+        self._layers = [layer for layer in self._layers if layer.label in _labels]
+        self._available_classes = {layer.annotation_class for layer in self._layers}
         self._str_tree = STRtree(self._layers)
 
     @property
@@ -552,7 +545,7 @@ class WsiAnnotations:
         cls,
         asap_xml: PathLike,
         scaling: float | None = None,
-        sorting: AnnotationSorting = AnnotationSorting.AREA,
+        sorting: AnnotationSorting | str = AnnotationSorting.AREA,
     ) -> WsiAnnotations:
         """
         Read annotations as an ASAP [1] XML file. ASAP is a tool for viewing and annotating whole slide images.
@@ -626,7 +619,10 @@ class WsiAnnotations:
 
     @classmethod
     def from_halo_xml(
-        cls, halo_xml: PathLike, scaling: float | None = None, sorting: AnnotationSorting = AnnotationSorting.NONE
+        cls,
+        halo_xml: PathLike,
+        scaling: float | None = None,
+        sorting: AnnotationSorting | str = AnnotationSorting.NONE,
     ) -> WsiAnnotations:
         """
         Read annotations as a Halo [1] XML file.
@@ -963,27 +959,25 @@ class WsiAnnotations:
 
             self._layers += other
             for item in other:
-                if item.annotation_class not in self:
-                    self._available_classes.append(item.annotation_class)
+                self._available_classes.add(item.annotation_class)
         elif isinstance(other, WsiAnnotations):
             if self.sorting != other.sorting or self.offset_to_slide_bounds != other.offset_to_slide_bounds:
                 raise ValueError("")
             self._layers += other._layers
 
-            if self.tags is None:
+            if self._tags is None:
                 self._tags = other._tags
-            elif other.tags is not None:
+            elif other._tags is not None:
+                assert self
                 self._tags += other._tags
 
-            for available_class in other.available_classes:
-                if available_class not in self:
-                    self._available_classes.append(available_class)
+            self._available_classes.update(other.available_classes)
         else:
             return NotImplemented
         self._sort_layers_in_place()
         self._str_tree = STRtree(self._layers)
         return self
-    
+
     def __radd__(self, other: WsiAnnotations | Point | Polygon) -> WsiAnnotations:
         # in-place addition (+=) of Point and Polygon will raise a TypeError
         if not isinstance(other, (WsiAnnotations, Point, Polygon)):

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -785,7 +785,6 @@ class WsiAnnotations:
 
                 elif "paths" in curr_data:  # This is a complex polygon which needs to be parsed with the even-odd rule
                     curr_complex_polygon = _parse_darwin_complex_polygon(curr_data)
-                    print(f"COMPLEX DARWIN: with type {darwin_annotation_type}")
                     for polygon in curr_complex_polygon.geoms:
                         layers.append(Polygon(polygon, a_cls=_cls))
                 else:

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -22,9 +22,9 @@ import json
 import os
 import pathlib
 import xml.etree.ElementTree as ET
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum
-from typing import Any, Callable, ClassVar, Iterable, NamedTuple, Optional, Type, TypedDict, TypeVar, Union, cast
+from typing import Any, ClassVar, Iterable, NamedTuple, Optional, Type, TypedDict, TypeVar, Union, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -33,7 +33,6 @@ import shapely.affinity
 import shapely.geometry
 import shapely.validation
 from shapely import geometry
-from shapely import lib as shapely_lib
 from shapely.geometry import MultiPolygon as ShapelyMultiPolygon
 from shapely.geometry import Point as ShapelyPoint
 from shapely.geometry import Polygon as ShapelyPolygon
@@ -216,79 +215,12 @@ def _get_geojson_z_index(properties: dict[str, str | list[int]]) -> Optional[int
     return cast(int, z_index)
 
 
-def _is_rectangle(coordinates: list[list[list[float]]]) -> bool:
-    if len(coordinates) > 1:
-        return False
-    coords = coordinates[0]
-    # Create a polygon from the coordinates
-    poly = ShapelyPolygon(coords)
-
-    # Check if the polygon is valid and has four sides
-    if not poly.is_valid or len(poly.exterior.coords) != 5:
-        return False
-
-    # Get the list of coordinates (excluding the repeated last coordinate)
-    points = list(poly.exterior.coords[:-1])
-
-    # Check angles between consecutive edges to ensure they are 90 degrees
-    for i in range(4):
-        p1 = points[i - 1]  # Previous point
-        p2 = points[i]  # Current point
-        p3 = points[(i + 1) % 4]  # Next point
-
-        # Calculate vectors
-        vector1 = (p2[0] - p1[0], p2[1] - p1[1])
-        vector2 = (p3[0] - p2[0], p3[1] - p2[1])
-
-        # Calculate dot product and magnitudes of vectors
-        dot_product = vector1[0] * vector2[0] + vector1[1] * vector2[1]
-
-        # Check if angle is 90 degrees (dot product should be zero if vectors are perpendicular)
-        if not np.isclose(dot_product, 0.0, atol=1e-6):
-            return False
-
-    return True
-
-
-def transform(
-    geometry: Point | Polygon, transformation: Callable[[npt.NDArray[np.float_]], npt.NDArray[np.float_]]
-) -> Point | Polygon:
-    """
-    Transform a geometry. Function taken from Shapely 2.0.1 under the BSD 3-Clause "New" or "Revised" License.
-
-    Parameters
-    ----------
-    geometry : Point or Polygon
-    transformation : Callable
-        Function mapping a numpy array of coordinates to a new numpy array of coordinates.
-
-    Returns
-    -------
-    Point or Polygon
-        The transformed point
-    """
-    original_class = geometry.annotation_class
-    geometry_arr = np.array(geometry, dtype=np.object_)  # makes a copy
-    coordinates = shapely_lib.get_coordinates(geometry_arr, False, False)
-    new_coordinates = transformation(coordinates)
-    # check the array to yield understandable error messages
-    if not isinstance(new_coordinates, np.ndarray):
-        raise ValueError("The provided transformation did not return a numpy array")
-    if new_coordinates.dtype != np.float64:
-        raise ValueError(
-            "The provided transformation returned an array with an unexpected dtype ({new_coordinates.dtype})"
-        )
-    if new_coordinates.shape != coordinates.shape:
-        # if the shape is too small we will get a segfault
-        raise ValueError(
-            "The provided transformation returned an array with an unexpected shape ({new_coordinates.shape})"
-        )
-    geometry_arr = shapely_lib.set_coordinates(geometry_arr, new_coordinates)
-    returned_geometry = geometry_arr.item()
-
-    if original_class.annotation_type != "POINT":
-        return Polygon(returned_geometry, a_cls=original_class)
-    return Point(returned_geometry, a_cls=original_class)
+def _is_rectangle(polygon: Polygon | ShapelyPolygon) -> tuple[bool, bool]:
+    if not polygon.is_valid or len(polygon.exterior.coords) != 5 or len(polygon.interiors) != 0:
+        return False, False
+    min_rotated_rect = polygon.minimum_rotated_rectangle
+    aligned_rect = min_rotated_rect.minimum_rotated_rectangle
+    return (np.isclose(polygon.area, min_rotated_rect.area), min_rotated_rect == aligned_rect)
 
 
 class GeoJsonDict(TypedDict):
@@ -302,91 +234,22 @@ class GeoJsonDict(TypedDict):
     metadata: Optional[dict[str, str | list[str]]]
 
 
-class Point(ShapelyPoint):  # type: ignore
-    # https://github.com/shapely/shapely/issues/1233#issuecomment-1034324441
-    _id_to_attrs: ClassVar[dict[str, Any]] = {}
-    __slots__ = (
-        ShapelyPoint.__slots__
-    )  # slots must be the same for assigning __class__ - https://stackoverflow.com/a/52140968
-    name: str  # For documentation generation and static type checking
+class AnnotatedGeometry(geometry.base.BaseGeometry):
+    __slots__ = geometry.base.BaseGeometry.__slots__
+    _a_cls: ClassVar[dict[str, Any]] = {}
 
     def __init__(
         self,
-        coord: ShapelyPoint | tuple[float, float],
-        a_cls: AnnotationClass | None = None,
+        *args: Any,
+        **kwargs: Any,
     ) -> None:
-        self._id_to_attrs[str(id(self))] = dict(a_cls=a_cls)
+        # Get annotation_class from args and kwargs. We do this because the __new__ method takes different (kw)args
+        a_cls = next((arg for arg in args if isinstance(arg, AnnotationClass)), kwargs.get("a_cls", None))
+        self._a_cls[id(self)] = a_cls
 
     @property
     def annotation_class(self) -> AnnotationClass:
-        return self._id_to_attrs[str(id(self))]["a_cls"]  # type: ignore
-
-    @property
-    def annotation_type(self) -> AnnotationType | str:
-        return self.annotation_class.annotation_type
-
-    @property
-    def label(self) -> str:
-        return self.annotation_class.label
-
-    @property
-    def color(self) -> Optional[tuple[int, int, int]]:
-        return self.annotation_class.color
-
-    def __new__(cls, coord: tuple[float, float], *args: Any, **kwargs: Any) -> "Point":
-        point = super().__new__(cls, coord)
-        point.__class__ = cls
-        return point  # type: ignore
-
-    def __eq__(self, other: object) -> bool:
-        geometry_equal = self.equals(other)
-        if not geometry_equal:
-            return False
-
-        if not isinstance(other, type(self)):
-            return False
-
-        label_equal = self.label == other.label
-        type_equal = self.annotation_type == other.annotation_type
-        color_equal = self.color == other.color
-        return geometry_equal and label_equal and type_equal and color_equal
-
-    def __del__(self) -> None:
-        del self._id_to_attrs[str(id(self))]
-
-    def __getattr__(self, name: str) -> Any:
-        try:
-            return Point._id_to_attrs[str(id(self))][name]
-        except KeyError as e:
-            raise AttributeError(str(e)) from None
-
-    def __str__(self) -> str:
-        return f"{self.annotation_class}, {self.wkt}"
-
-    def __reduce__(self):  # type: ignore
-        return (
-            self.__class__,
-            (ShapelyPoint(self.xy), self.a_cls),
-        )
-
-    def __setstate__(self, state) -> None:  # type: ignore
-        self._id_to_attrs[str(id(self))] = dict(a_cls=self.a_cls)
-
-
-class Polygon(ShapelyPolygon):  # type: ignore
-    _id_to_attrs: ClassVar[dict[str, Any]] = {}
-    __slots__ = ShapelyPolygon.__slots__
-
-    def __init__(
-        self,
-        shell: ShapelyPolygon | tuple[float, float],
-        a_cls: AnnotationClass | None = None,
-    ) -> None:
-        self._id_to_attrs[str(id(self))] = dict(a_cls=a_cls)
-
-    @property
-    def annotation_class(self) -> AnnotationClass:
-        return cast(AnnotationClass, self._id_to_attrs[str(id(self))]["a_cls"])
+        return cast(AnnotationClass, self._a_cls[id(self)])
 
     @property
     def annotation_type(self) -> AnnotationType | str:
@@ -404,88 +267,85 @@ class Polygon(ShapelyPolygon):  # type: ignore
     def z_index(self) -> Optional[int]:
         return self.annotation_class.z_index
 
-    def intersect_with_box(self, other: ShapelyPolygon) -> Optional[list["Polygon"]]:
-        pre_area = self.area
-        if not self.is_valid:
-            valid_polygon = make_valid(self)
-        else:
-            valid_polygon = self
+    def __del__(self) -> None:
+        if id(self) in self._a_cls:
+            del self._a_cls[id(self)]
 
-        result = valid_polygon.intersection(other)
-        post_area = result.area
-        if pre_area > 0 and post_area == 0:
-            return None
-
-        annotation_class = self.annotation_class
-
-        if self.annotation_type == AnnotationType.BOX:
-            # Verify if this is still a box
-            if not _is_rectangle(shapely.geometry.mapping(result)["coordinates"]):
-                annotation_class = AnnotationClass(
-                    label=self.label,
-                    annotation_type=AnnotationType.POLYGON,
-                    color=self.color,
-                    z_index=self.z_index,
-                )
-
-        if isinstance(result, ShapelyPolygon):
-            return [Polygon(result, a_cls=annotation_class)]
-        elif isinstance(result, ShapelyMultiPolygon):
-            return [Polygon(geom, a_cls=annotation_class) for geom in result.geoms if geom.area > 0]
-        elif isinstance(result, shapely.geometry.collection.GeometryCollection):
-            return [Polygon(geom, a_cls=annotation_class) for geom in result.geoms if geom.area > 0]
-        else:
-            raise NotImplementedError(f"{type(result)}")
-
-    def __new__(cls, coords: Union[tuple[float, float], ShapelyPolygon], *args: Any, **kwargs: Any) -> "Polygon":
-        if isinstance(coords, ShapelyPolygon):
-            instance = super().__new__(cls, coords.exterior.coords, [ring.coords for ring in coords.interiors])
-        else:
-            instance = super().__new__(cls, coords)
-        instance.__class__ = cls
-        return cast("Polygon", instance)
+    def __str__(self) -> str:
+        return f"{self.annotation_class}, {self.wkt}"
 
     def __eq__(self, other: object) -> bool:
         geometry_equal = self.equals(other)
         if not geometry_equal:
             return False
 
+        # TODO: Check evaluation with ShapelyPolygon / ShapelyPoint. Does it evaluate to True?
         if not isinstance(other, type(self)):
             return False
 
-        label_equal = self.label == other.label
-        z_index_equal = self.z_index == other.z_index
-        type_equal = self.annotation_type == other.annotation_type
-        color_equal = self.color == other.color
-        return geometry_equal and label_equal and z_index_equal and type_equal and color_equal
+        if not other.annotation_class == self.annotation_class:
+            return False
+        return True
 
-    def __del__(self) -> None:
-        if str(id(self)) in self._id_to_attrs:
-            del self._id_to_attrs[str(id(self))]
 
-    def __getattr__(self, name: str) -> Any:
-        try:
-            return Polygon._id_to_attrs[str(id(self))][name]
-        except KeyError as e:
-            raise AttributeError(f"{name} attribute not found") from e
+class Point(ShapelyPoint, AnnotatedGeometry):
+    __slots__ = ShapelyPoint.__slots__
 
-    def __str__(self) -> str:
-        return f"{self.annotation_class}, {self.wkt}"
+    def __new__(
+        cls, coord: ShapelyPoint | tuple[float, float], a_cls: AnnotationClass = None
+    ) -> "Point":
+        point = super().__new__(cls, coord)
+        point.__class__ = cls
+        return cast("Point", point)
+
+    def __reduce__(self):  # type: ignore
+        return (self.__class__, (ShapelyPoint(self.xy), self.annotation_class))
+
+
+class Polygon(ShapelyPolygon, AnnotatedGeometry):
+    __slots__ = ShapelyPolygon.__slots__
+
+    def __new__(
+        cls,
+        shell: Union[tuple[float, float], ShapelyPolygon],
+        holes: Optional[list[list[float, float]]] = None,
+        a_cls: Optional[AnnotationClass] = None,
+    ) -> "Polygon":
+        instance = super().__new__(cls, shell, holes)
+        instance.__class__ = cls
+        return cast("Polygon", instance)
+
+    def intersect_with_box(
+        self, other: ShapelyPolygon, affine_transform_matrix: list[float]
+    ) -> Optional[list["Polygon"]]:
+        result = make_valid(self).intersection(other)
+        if self.area > 0 and result.area == 0:
+            return None
+
+        # Verify if this box is still a box. Create annotation_type to polygon if that is not the case
+        if self.annotation_type == AnnotationType.BOX and not _is_rectangle(result)[0]:
+            annotation_class = replace(self.annotation_class, annotation_type=AnnotationType.POLYGON)
+        else:
+            annotation_class = self.annotation_class
+
+        transformed_results = shapely.affinity.affine_transform(result, affine_transform_matrix)
+        # FIXME: Can we even have MultiPolygons at this stage?
+        if isinstance(transformed_results, ShapelyPolygon):
+            return [Polygon(transformed_results, a_cls=annotation_class)]
+        elif isinstance(transformed_results, (ShapelyMultiPolygon, shapely.geometry.collection.GeometryCollection)):
+            return [Polygon(geom, a_cls=annotation_class) for geom in transformed_results.geoms if geom.area > 0]
+        else:
+            raise NotImplementedError(f"{type(result)}")
 
     def __reduce__(self):  # type: ignore
         return (
             self.__class__,
-            (ShapelyPolygon(self.exterior.coords[:], [ring.coords[:] for ring in self.interiors]), self.a_cls),
+            (self.exterior.coords[:], [ring.coords[:] for ring in self.interiors], self.annotation_class),
         )
-
-    def __setstate__(self, state) -> None:  # type: ignore
-        self._id_to_attrs[str(id(self))] = dict(a_cls=self.a_cls)
-
 
 class CoordinatesDict(TypedDict):
     type: str
     coordinates: list[list[list[float]]]
-
 
 def shape(
     coordinates: CoordinatesDict,
@@ -493,36 +353,27 @@ def shape(
     color: Optional[tuple[int, int, int]] = None,
     z_index: Optional[int] = None,
 ) -> list[Polygon | Point]:
-    geom_type = coordinates.get("type", None)
-    if geom_type is None:
+    geom_type = coordinates.get("type", "not_found").lower()
+    if geom_type == "not_found":
         raise ValueError("No type found in coordinates.")
-    geom_type = geom_type.lower()
+    elif geom_type in ["point", "multipoint"]:
+        if z_index is not None:
+            raise AnnotationError("z_index is not supported for point annotations.")
 
-    if geom_type in ["point", "multipoint"] and z_index is not None:
-        raise AnnotationError("z_index is not supported for point annotations.")
-
-    if geom_type == "point":
-        annotation_class = AnnotationClass(label=label, annotation_type=AnnotationType.POINT, color=color, z_index=None)
+        annotation_class = AnnotationClass(
+            label=label, annotation_type=AnnotationType.POINT, color=color, z_index=None
+        )
+        _coordinates = coordinates["coordinates"]
         return [
-            Point(
-                np.asarray(coordinates["coordinates"]),
-                a_cls=annotation_class,
-            )
+            Point(np.asarray(c), a_cls=annotation_class)
+            for c in (_coordinates if geom_type == "multipoint" else [_coordinates])
         ]
-    if geom_type == "multipoint":
-        annotation_class = AnnotationClass(label=label, annotation_type=AnnotationType.POINT, color=color, z_index=None)
-        return [Point(np.asarray(c), a_cls=annotation_class) for c in coordinates["coordinates"]]
 
     if geom_type == "polygon":
         _coordinates = coordinates["coordinates"]
-        annotation_type = AnnotationType.BOX if _is_rectangle(_coordinates) else AnnotationType.POLYGON
+        annotation_type = AnnotationType.BOX if _is_rectangle(Polygon(_coordinates[0]))[0] else AnnotationType.POLYGON
         annotation_class = AnnotationClass(label=label, annotation_type=annotation_type, color=color, z_index=z_index)
-        # TODO: This needs to work by directly constructing it with an a_cls
-        polygon = ShapelyPolygon(
-            shell=np.asarray(_coordinates[0]),
-            holes=[np.asarray(hole) for hole in _coordinates[1:]],
-        )
-        return [Polygon(polygon, a_cls=annotation_class)]
+        return [Polygon(shell=np.asarray(_coordinates[0]), holes=[np.asarray(hole) for hole in _coordinates[1:]], a_cls=annotation_class)]
     if geom_type == "multipolygon":
         annotation_class = AnnotationClass(
             label=label, annotation_type=AnnotationType.POLYGON, color=color, z_index=z_index
@@ -1126,25 +977,22 @@ class WsiAnnotations:
         curr_indices = self._str_tree.query(query_box)
         # This is needed because the STRTree returns (seemingly) arbitrary order, and this would destroy the order
         curr_indices.sort()
-        filtered_annotations = self._str_tree.geometries.take(curr_indices).tolist()
+        filtered_annotations: list[Point | Polygon] = self._str_tree.geometries.take(curr_indices).tolist()
 
         cropped_annotations = []
+        affine_transform_matrix = [scaling, 0, 0, scaling, -location[0], -location[1]]
         for annotation in filtered_annotations:
             if annotation.annotation_type in (AnnotationType.BOX, AnnotationType.POLYGON):
-                _annotations = annotation.intersect_with_box(query_box)
+                _annotations = annotation.intersect_with_box(query_box, affine_transform_matrix=affine_transform_matrix)
                 if _annotations is not None:
                     cropped_annotations += _annotations
+            elif annotation.annotation_type == AnnotationType.POINT:
+                _annotation = shapely.affinity.affine_transform(annotation, affine_transform_matrix)
+                cropped_annotations.append(Point(_annotation, a_cls=annotation.annotation_class))
+            # Tags could end up here in theory?
             else:
                 cropped_annotations.append(annotation)
-
-        def _affine_coords(coords: npt.NDArray[np.float_]) -> npt.NDArray[np.float_]:
-            return coords * scaling - np.asarray(location, dtype=np.float_)
-
-        output: list[Polygon | Point] = []
-        for annotation in cropped_annotations:
-            annotation = transform(annotation, _affine_coords)
-            output.append(annotation)
-        return output
+        return cropped_annotations
 
     def __contains__(self, item: Union[str, AnnotationClass]) -> bool:
         if isinstance(item, str):

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -196,6 +196,25 @@ def _get_geojson_color(properties: dict[str, str | list[int]]) -> Optional[tuple
 
     return cast(tuple[int, int, int], tuple(color))
 
+def _get_geojson_z_index(properties: dict[str, str | list[int]]) -> Optional[int]:
+    """Parse the properties dictionary of a GeoJSON object to get the z_index`.
+
+    Arguments
+    ---------
+    properties : dict
+        The properties dictionary of a GeoJSON object.
+
+    Returns
+    -------
+    Optional[tuple[int, int, int]]
+        The color of the object as a tuple of RGB values.
+    """
+    z_index = properties.get("z_index", None)
+    if z_index is None:
+        return None
+
+    return cast(int, z_index)
+
 
 def _is_rectangle(coordinates: list[list[list[float]]]) -> bool:
     if len(coordinates) > 1:
@@ -524,7 +543,9 @@ def shape(
     raise AnnotationError(f"Unsupported geom_type {geom_type}")
 
 
-def _geometry_to_geojson(geometry: Polygon | Point, label: str, color: tuple[int, int, int] | None) -> dict[str, Any]:
+def _geometry_to_geojson(
+    geometry: Polygon | Point, label: str, color: tuple[int, int, int] | None, z_index: int | None
+) -> dict[str, Any]:
     """Function to convert a geometry to a GeoJSON object.
 
     Parameters
@@ -535,6 +556,8 @@ def _geometry_to_geojson(geometry: Polygon | Point, label: str, color: tuple[int
         The label name
     color : tuple[int, int, int]
         The color of the object in RGB values
+    z_index : int
+        The z-index of the object
 
     Returns
     -------
@@ -553,6 +576,9 @@ def _geometry_to_geojson(geometry: Polygon | Point, label: str, color: tuple[int
     }
     if color is not None:
         data["properties"]["classification"]["color"] = color
+
+    if z_index is not None:
+        data["properties"]["classification"]["z_index"] = z_index
 
     return data
 
@@ -747,13 +773,15 @@ class WsiAnnotations:
                     if "classification" in properties:
                         _label = properties["classification"]["name"]
                         _color = _get_geojson_color(properties["classification"])
+                        _z_index = _get_geojson_z_index(properties["classification"])
                     elif properties.get("objectType", None) == "annotation":
                         _label = properties["name"]
                         _color = _get_geojson_color(properties)
+                        _z_index = _get_geojson_z_index(properties)
                     else:
                         raise ValueError("Could not find label in the GeoJSON properties.")
 
-                    _geometry = shape(x["geometry"], label=_label, color=_color)
+                    _geometry = shape(x["geometry"], label=_label, color=_color, z_index=_z_index)
                     layers += _geometry
 
         _sort_layers_in_place(layers, sorting)
@@ -1007,7 +1035,12 @@ class WsiAnnotations:
 
         # # This used to be it.
         for idx, curr_annotation in enumerate(self._layers):
-            json_dict = _geometry_to_geojson(curr_annotation, label=curr_annotation.label, color=curr_annotation.color)
+            json_dict = _geometry_to_geojson(
+                curr_annotation,
+                label=curr_annotation.label,
+                color=curr_annotation.color,
+                z_index=curr_annotation.z_index,
+            )
             json_dict["id"] = str(idx)
             data["features"].append(json_dict)
 

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -17,13 +17,14 @@ from __future__ import annotations
 
 import copy
 import errno
+import functools
 import json
 import os
 import pathlib
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass, replace
 from enum import Enum
-from typing import Any, ClassVar, Iterable, Optional, Type, TypedDict, TypeVar, Union, cast
+from typing import Any, ClassVar, Iterable, NamedTuple, Optional, Type, TypedDict, TypeVar, Union, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -40,7 +41,7 @@ from shapely.validation import make_valid
 
 from dlup._exceptions import AnnotationError
 from dlup._types import GenericNumber, PathLike
-from dlup.utils.annotations_utils import _get_geojson_color, _get_geojson_z_index, _get_v7_metadata, _hex_to_rgb
+from dlup.utils.annotations_utils import _get_geojson_color, _get_geojson_z_index, _hex_to_rgb
 from dlup.utils.imports import DARWIN_SDK_AVAILABLE, PYHALOXML_AVAILABLE
 
 # TODO:
@@ -74,6 +75,7 @@ class AnnotationTypeToDLUPAnnotationType(Enum):
     complex_polygon = AnnotationType.POLYGON
     keypoint = AnnotationType.POINT
     tag = AnnotationType.TAG
+    raster_layer = AnnotationType.RASTER
 
     @classmethod
     def from_string(cls, annotation_type: str) -> AnnotationType:
@@ -139,6 +141,44 @@ class AnnotationClass:
 
         if self.annotation_type in (AnnotationType.POINT, AnnotationType.TAG) and self.z_index is not None:
             raise ValueError("z_index is not supported for point annotations or tags.")
+
+
+class DarwinV7Metadata(NamedTuple):
+    label: str
+    color: tuple[int, int, int]
+    annotation_type: AnnotationType
+
+
+@functools.lru_cache(maxsize=None)
+def _get_v7_metadata(filename: pathlib.Path) -> Optional[dict[tuple[str, str], DarwinV7Metadata]]:
+    if not DARWIN_SDK_AVAILABLE:
+        raise RuntimeError("`darwin` is not available. Install using `python -m pip install darwin-py`.")
+    import darwin.path_utils
+
+    if not filename.is_dir():
+        raise RuntimeError("Provide the path to the root folder of the Darwin V7 annotations")
+
+    v7_metadata_fn = filename / ".v7" / "metadata.json"
+    if not v7_metadata_fn.exists():
+        return None
+    v7_metadata = darwin.path_utils.parse_metadata(v7_metadata_fn)
+    output = {}
+    for sample in v7_metadata["classes"]:
+        annotation_type = AnnotationTypeToDLUPAnnotationType.from_string(sample["type"])
+        # This is not implemented and can be skipped. The main function will raise a NonImplementedError
+        if annotation_type == AnnotationType.RASTER:
+            continue
+
+        label = sample["name"]
+        color = sample["color"][5:-1].split(",")
+        if color[-1] != "1.0":
+            raise RuntimeError("Expected A-channel of color to be 1.0")
+        rgb_colors = (int(color[0]), int(color[1]), int(color[2]))
+
+        output[(label, annotation_type.value)] = DarwinV7Metadata(
+            label=label, color=rgb_colors, annotation_type=annotation_type
+        )
+    return output
 
 
 def _is_rectangle(polygon: Polygon | ShapelyPolygon) -> bool:
@@ -719,7 +759,7 @@ class WsiAnnotations:
             if annotation_type == AnnotationType.RASTER:
                 raise NotImplementedError("Raster annotations are not supported.")
 
-            annotation_color = v7_metadata[(name, darwin_annotation_type)].color if v7_metadata else None
+            annotation_color = v7_metadata[(name, annotation_type.value)].color if v7_metadata else None
 
             if annotation_type == AnnotationType.TAG:
                 tags.append(
@@ -745,6 +785,7 @@ class WsiAnnotations:
 
                 elif "paths" in curr_data:  # This is a complex polygon which needs to be parsed with the even-odd rule
                     curr_complex_polygon = _parse_darwin_complex_polygon(curr_data)
+                    print(f"COMPLEX DARWIN: with type {darwin_annotation_type}")
                     for polygon in curr_complex_polygon.geoms:
                         layers.append(Polygon(polygon, a_cls=_cls))
                 else:

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -974,12 +974,14 @@ class WsiAnnotations:
 
         if isinstance(other, list):
             if not all(isinstance(item, (Point, Polygon)) for item in other):
-                raise TypeError("")
+                raise TypeError("can only add list purely containing Point and Polygon objects to WsiAnnotations")
             new_layers = self._layers + other
             new_tags = self.tags
         elif isinstance(other, WsiAnnotations):
             if self.sorting != other.sorting or self.offset_to_slide_bounds != other.offset_to_slide_bounds:
-                raise ValueError("")
+                raise ValueError(
+                    "Both sorting and offset_to_slide_bounds must be the same to add WsiAnnotations together."
+                )
             new_layers = self._layers + other._layers
             new_tags = self.tags if self.tags is not None else [] + other.tags if other.tags is not None else None
         else:
@@ -994,14 +996,16 @@ class WsiAnnotations:
 
         if isinstance(other, list):
             if not all(isinstance(item, (Point, Polygon)) for item in other):
-                raise TypeError("")
+                raise TypeError("can only add list purely containing Point and Polygon objects to WsiAnnotations")
 
             self._layers += other
             for item in other:
                 self._available_classes.add(item.annotation_class)
         elif isinstance(other, WsiAnnotations):
             if self.sorting != other.sorting or self.offset_to_slide_bounds != other.offset_to_slide_bounds:
-                raise ValueError("")
+                raise ValueError(
+                    "Both sorting and offset_to_slide_bounds must be the same to add WsiAnnotations together."
+                )
             self._layers += other._layers
 
             if self._tags is None:
@@ -1017,10 +1021,17 @@ class WsiAnnotations:
         self._str_tree = STRtree(self._layers)
         return self
 
-    def __radd__(self, other: WsiAnnotations | Point | Polygon) -> WsiAnnotations:
+    def __radd__(self, other: WsiAnnotations | Point | Polygon | list[Point | Polygon]) -> WsiAnnotations:
         # in-place addition (+=) of Point and Polygon will raise a TypeError
-        if not isinstance(other, (WsiAnnotations, Point, Polygon)):
+        if not isinstance(other, (WsiAnnotations, Point, Polygon, list)):
             return NotImplemented
+        if isinstance(other, list):
+            if not all(isinstance(item, (Point, Polygon)) for item in other):
+                raise TypeError("can only add list purely containing Point and Polygon objects to WsiAnnotations")
+            raise TypeError(
+                "use the __add__ or __iadd__ operator instead of __radd__ when working with lists to avoid \
+                            unexpected behavior."
+            )
         return self + other
 
     def __sub__(self, other: WsiAnnotations | Point | Polygon) -> WsiAnnotations:

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -436,22 +436,23 @@ class WsiAnnotations:
 
         Parameters
         ----------
-        labels : tuple or list
-            The list or tuple of labels
+        labels : tuple or list or string
+            The list or tuple of labels or a single string of a label
 
         Returns
         -------
         None
         """
-        self._available_classes = []
-        self._new_layers = []
+        new_available_classes: list[AnnotationClass] = []
+        new_layers: list[Point | Polygon] = []
         _labels = [labels] if isinstance(labels, str) else labels
         for layer in self._layers:
             if layer.label in _labels:
-                self._available_classes += [layer.annotation_class]
-                self._new_layers += [layer]
+                new_available_classes += [layer.annotation_class]
+                new_layers += [layer]
 
-        self._layers = self._new_layers
+        self._available_classes = new_available_classes
+        self._layers = new_layers
         self._str_tree = STRtree(self._layers)
 
     @property

--- a/dlup/annotations.py
+++ b/dlup/annotations.py
@@ -24,7 +24,7 @@ import pathlib
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass, replace
 from enum import Enum
-from typing import Any, ClassVar, Iterable, NamedTuple, Optional, Type, TypedDict, TypeVar, Union, cast
+from typing import Any, Callable, ClassVar, Iterable, NamedTuple, Optional, Type, TypedDict, TypeVar, Union, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -33,6 +33,7 @@ import shapely.affinity
 import shapely.geometry
 import shapely.validation
 from shapely import geometry
+from shapely import lib as shapely_lib
 from shapely.geometry import MultiPolygon as ShapelyMultiPolygon
 from shapely.geometry import Point as ShapelyPoint
 from shapely.geometry import Polygon as ShapelyPolygon
@@ -82,9 +83,7 @@ class AnnotationTypeToDLUPAnnotationType(Enum):
         try:
             return cls[annotation_type].value
         except KeyError:
-            raise NotImplementedError(
-                f"annotation_type {annotation_type} is not implemented or not a valid dlup type."
-            )
+            raise NotImplementedError(f"annotation_type {annotation_type} is not implemented or not a valid dlup type.")
 
 
 class AnnotationSorting(str, Enum):
@@ -193,6 +192,45 @@ def _is_alligned_rectangle(polygon: Polygon | ShapelyPolygon) -> bool:
     min_rotated_rect = polygon.minimum_rotated_rectangle
     aligned_rect = min_rotated_rect.minimum_rotated_rectangle
     return bool(min_rotated_rect == aligned_rect)
+
+
+def transform(
+    geometry: Point | Polygon, transformation: Callable[[npt.NDArray[np.float_]], npt.NDArray[np.float_]]
+) -> Point | Polygon:
+    """
+    Transform a geometry. Function taken from Shapely 2.0.1 under the BSD 3-Clause "New" or "Revised" License.
+    Parameters
+    ----------
+    geometry : Point or Polygon
+    transformation : Callable
+        Function mapping a numpy array of coordinates to a new numpy array of coordinates.
+    Returns
+    -------
+    Point or Polygon
+        The transformed point
+    """
+    original_class = geometry.annotation_class
+    geometry_arr = np.array(geometry, dtype=np.object_)  # makes a copy
+    coordinates = shapely_lib.get_coordinates(geometry_arr, False, False)
+    new_coordinates = transformation(coordinates)
+    # check the array to yield understandable error messages
+    if not isinstance(new_coordinates, np.ndarray):
+        raise ValueError("The provided transformation did not return a numpy array")
+    if new_coordinates.dtype != np.float64:
+        raise ValueError(
+            "The provided transformation returned an array with an unexpected dtype ({new_coordinates.dtype})"
+        )
+    if new_coordinates.shape != coordinates.shape:
+        # if the shape is too small we will get a segfault
+        raise ValueError(
+            "The provided transformation returned an array with an unexpected shape ({new_coordinates.shape})"
+        )
+    geometry_arr = shapely_lib.set_coordinates(geometry_arr, new_coordinates)
+    returned_geometry = geometry_arr.item()
+
+    if original_class.annotation_type != "POINT":
+        return Polygon(returned_geometry, a_cls=original_class)
+    return Point(returned_geometry, a_cls=original_class)
 
 
 class GeoJsonDict(TypedDict):
@@ -338,9 +376,7 @@ def shape(
         if z_index is not None:
             raise AnnotationError("z_index is not supported for point annotations.")
 
-        annotation_class = AnnotationClass(
-            label=label, annotation_type=AnnotationType.POINT, color=color, z_index=None
-        )
+        annotation_class = AnnotationClass(label=label, annotation_type=AnnotationType.POINT, color=color, z_index=None)
         _coordinates = coordinates["coordinates"]
         return [
             Point(np.asarray(c), a_cls=annotation_class)
@@ -938,12 +974,14 @@ class WsiAnnotations:
             else:
                 cropped_annotations.append(annotation)
 
-        affine_matrix = [scaling, 0, 0, scaling, -location[0], -location[1]]
-        transformed_annotations = [
-            type(_ann)(shapely.affinity.affine_transform(_ann, affine_matrix), a_cls=_ann.annotation_class)
-            for _ann in cropped_annotations
-        ]
-        return transformed_annotations
+        def _affine_coords(coords: npt.NDArray[np.float_]) -> npt.NDArray[np.float_]:
+            return coords * scaling - np.asarray(location, dtype=np.float_)
+
+        output: list[Polygon | Point] = []
+        for annotation in cropped_annotations:
+            annotation = transform(annotation, _affine_coords)
+            output.append(annotation)
+        return output
 
     def __str__(self) -> str:
         return (

--- a/dlup/backends/openslide_backend.py
+++ b/dlup/backends/openslide_backend.py
@@ -12,8 +12,8 @@ import openslide.lowlevel as openslide_lowlevel
 import pyvips
 from packaging.version import Version
 
-from dlup.backends.common import AbstractSlideBackend
 from dlup._types import PathLike
+from dlup.backends.common import AbstractSlideBackend
 from dlup.utils.image import check_if_mpp_is_valid
 
 TIFF_PROPERTY_NAME_RESOLUTION_UNIT = "tiff.ResolutionUnit"

--- a/dlup/backends/pyvips_backend.py
+++ b/dlup/backends/pyvips_backend.py
@@ -10,8 +10,8 @@ import openslide
 import pyvips
 from packaging.version import Version
 
-from dlup.backends.common import AbstractSlideBackend
 from dlup._types import PathLike
+from dlup.backends.common import AbstractSlideBackend
 from dlup.utils.image import check_if_mpp_is_valid
 
 PYVIPS_ASSOCIATED_IMAGES = "slide-associated-images"

--- a/dlup/backends/tifffile_backend.py
+++ b/dlup/backends/tifffile_backend.py
@@ -5,8 +5,8 @@ import numpy as np
 import pyvips
 import tifffile
 
-from dlup.backends.common import AbstractSlideBackend
 from dlup._types import PathLike
+from dlup.backends.common import AbstractSlideBackend
 from dlup.utils.tifffile_utils import get_tile
 
 

--- a/dlup/data/dataset.py
+++ b/dlup/data/dataset.py
@@ -32,12 +32,12 @@ import pyvips
 from numpy.typing import NDArray
 
 from dlup import BoundaryMode, SlideImage
+from dlup._types import PathLike, ROIType
 from dlup.annotations import Point, Polygon, WsiAnnotations
 from dlup.backends.common import AbstractSlideBackend
 from dlup.background import compute_masked_indices
 from dlup.tiling import Grid, GridOrder, TilingMode
 from dlup.tools import ConcatSequences, MapSequence
-from dlup._types import PathLike, ROIType
 from dlup.utils.backends import ImageBackend
 
 MaskTypes = Union["SlideImage", npt.NDArray[np.int_], "WsiAnnotations"]

--- a/dlup/data/transforms.py
+++ b/dlup/data/transforms.py
@@ -232,17 +232,17 @@ def rename_labels(annotations: Iterable[_AnnotationsTypes], remap_labels: dict[s
             output_annotations.append(annotation)
             continue
 
-        if annotation.a_cls.annotation_type == AnnotationType.BOX:
+        if annotation.annotation_class.annotation_type == AnnotationType.BOX:
             a_cls = AnnotationClass(label=remap_labels[label], annotation_type=AnnotationType.BOX)
             output_annotations.append(dlup.annotations.Polygon(annotation, a_cls=a_cls))
-        elif annotation.a_cls.annotation_type == AnnotationType.POLYGON:
+        elif annotation.annotation_class.annotation_type == AnnotationType.POLYGON:
             a_cls = AnnotationClass(label=remap_labels[label], annotation_type=AnnotationType.POLYGON)
             output_annotations.append(dlup.annotations.Polygon(annotation, a_cls=a_cls))
-        elif annotation.a_cls.annotation_type == AnnotationType.POINT:
+        elif annotation.annotation_class.annotation_type == AnnotationType.POINT:
             a_cls = AnnotationClass(label=remap_labels[label], annotation_type=AnnotationType.POINT)
             output_annotations.append(dlup.annotations.Point(annotation, a_cls=a_cls))
         else:
-            raise AnnotationError(f"Unsupported annotation type {annotation.a_cls.a_cls}")
+            raise AnnotationError(f"Unsupported annotation type {annotation.annotation_class.annotation_type}")
 
     return output_annotations
 

--- a/dlup/utils/annotations_utils.py
+++ b/dlup/utils/annotations_utils.py
@@ -1,39 +1,4 @@
-import functools
-from dlup.utils.imports import DARWIN_SDK_AVAILABLE
-from typing import NamedTuple, Optional, cast
-from pathlib import Path
-
-class DarwinV7Metadata(NamedTuple):
-    label: str
-    color: tuple[int, int, int]
-    annotation_type: str
-
-@functools.lru_cache(maxsize=None)
-def _get_v7_metadata(filename: Path) -> Optional[dict[tuple[str, str], DarwinV7Metadata]]:
-    if not DARWIN_SDK_AVAILABLE:
-        raise RuntimeError("`darwin` is not available. Install using `python -m pip install darwin-py`.")
-    import darwin.path_utils
-
-    if not filename.is_dir():
-        raise RuntimeError("Provide the path to the root folder of the Darwin V7 annotations")
-
-    v7_metadata_fn = filename / ".v7" / "metadata.json"
-    if not v7_metadata_fn.exists():
-        return None
-    v7_metadata = darwin.path_utils.parse_metadata(v7_metadata_fn)
-    output = {}
-    for sample in v7_metadata["classes"]:
-        annotation_type = sample["type"]
-        label = sample["name"]
-        color = sample["color"][5:-1].split(",")
-        if color[-1] != "1.0":
-            raise RuntimeError("Expected A-channel of color to be 1.0")
-        rgb_colors = (int(color[0]), int(color[1]), int(color[2]))
-
-        output[(label, annotation_type)] = DarwinV7Metadata(
-            label=label, color=rgb_colors, annotation_type=annotation_type
-        )
-    return output
+from typing import Optional, cast
 
 
 def _hex_to_rgb(hex_color: str) -> tuple[int, int, int]:

--- a/dlup/utils/annotations_utils.py
+++ b/dlup/utils/annotations_utils.py
@@ -1,0 +1,53 @@
+from typing import Optional, cast
+
+def _hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
+    if "#" not in hex_color:
+        if hex_color == "black":
+            return 0, 0, 0
+    hex_color = hex_color.lstrip("#")
+
+    # Convert the string from hex to an integer and extract each color component
+    r = int(hex_color[0:2], 16)
+    g = int(hex_color[2:4], 16)
+    b = int(hex_color[4:6], 16)
+    return r, g, b
+
+
+def _get_geojson_color(properties: dict[str, str | list[int]]) -> Optional[tuple[int, int, int]]:
+    """Parse the properties dictionary of a GeoJSON object to get the color.
+
+    Arguments
+    ---------
+    properties : dict
+        The properties dictionary of a GeoJSON object.
+
+    Returns
+    -------
+    Optional[tuple[int, int, int]]
+        The color of the object as a tuple of RGB values.
+    """
+    color = properties.get("color", None)
+    if color is None:
+        return None
+
+    return cast(tuple[int, int, int], tuple(color))
+
+
+def _get_geojson_z_index(properties: dict[str, str | list[int]]) -> Optional[int]:
+    """Parse the properties dictionary of a GeoJSON object to get the z_index`.
+
+    Arguments
+    ---------
+    properties : dict
+        The properties dictionary of a GeoJSON object.
+
+    Returns
+    -------
+    Optional[tuple[int, int, int]]
+        The color of the object as a tuple of RGB values.
+    """
+    z_index = properties.get("z_index", None)
+    if z_index is None:
+        return None
+
+    return cast(int, z_index)

--- a/dlup/utils/annotations_utils.py
+++ b/dlup/utils/annotations_utils.py
@@ -1,4 +1,40 @@
-from typing import Optional, cast
+import functools
+from dlup.utils.imports import DARWIN_SDK_AVAILABLE
+from typing import NamedTuple, Optional, cast
+from pathlib import Path
+
+class DarwinV7Metadata(NamedTuple):
+    label: str
+    color: tuple[int, int, int]
+    annotation_type: str
+
+@functools.lru_cache(maxsize=None)
+def _get_v7_metadata(filename: Path) -> Optional[dict[tuple[str, str], DarwinV7Metadata]]:
+    if not DARWIN_SDK_AVAILABLE:
+        raise RuntimeError("`darwin` is not available. Install using `python -m pip install darwin-py`.")
+    import darwin.path_utils
+
+    if not filename.is_dir():
+        raise RuntimeError("Provide the path to the root folder of the Darwin V7 annotations")
+
+    v7_metadata_fn = filename / ".v7" / "metadata.json"
+    if not v7_metadata_fn.exists():
+        return None
+    v7_metadata = darwin.path_utils.parse_metadata(v7_metadata_fn)
+    output = {}
+    for sample in v7_metadata["classes"]:
+        annotation_type = sample["type"]
+        label = sample["name"]
+        color = sample["color"][5:-1].split(",")
+        if color[-1] != "1.0":
+            raise RuntimeError("Expected A-channel of color to be 1.0")
+        rgb_colors = (int(color[0]), int(color[1]), int(color[2]))
+
+        output[(label, annotation_type)] = DarwinV7Metadata(
+            label=label, color=rgb_colors, annotation_type=annotation_type
+        )
+    return output
+
 
 def _hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
     if "#" not in hex_color:

--- a/dlup/writers.py
+++ b/dlup/writers.py
@@ -19,8 +19,8 @@ from tifffile import tifffile
 
 import dlup
 from dlup._libtiff_tiff_writer import LibtiffTiffWriter
-from dlup.tiling import Grid, GridOrder, TilingMode
 from dlup._types import PathLike
+from dlup.tiling import Grid, GridOrder, TilingMode
 from dlup.utils.tifffile_utils import get_tile
 
 

--- a/tests/backends/test_openslide_backend.py
+++ b/tests/backends/test_openslide_backend.py
@@ -8,6 +8,7 @@ import pytest
 import pyvips
 
 from dlup._exceptions import UnsupportedSlideError
+from dlup._types import PathLike
 from dlup.backends.openslide_backend import (
     TIFF_PROPERTY_NAME_RESOLUTION_UNIT,
     TIFF_PROPERTY_NAME_X_RESOLUTION,
@@ -15,7 +16,6 @@ from dlup.backends.openslide_backend import (
     OpenSlideSlide,
     _get_mpp_from_tiff,
 )
-from dlup._types import PathLike
 
 from ..common import SlideConfig, get_sample_nonuniform_image
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -5,10 +5,10 @@ import json
 import pathlib
 import pickle
 import tempfile
+from copy import copy, deepcopy
 
 import pytest
 import shapely.geometry
-from copy import copy, deepcopy
 from shapely import Point as ShapelyPoint
 from shapely import Polygon as ShapelyPolygon
 
@@ -139,18 +139,24 @@ class TestAnnotations:
     def test_read_darwin_v7(self):
         if not DARWIN_SDK_AVAILABLE:
             return None
-
+        print(self.v7_annotations.available_classes)
         assert len(self.v7_annotations.available_classes) == 5
-        assert self.v7_annotations.available_classes[0].label == "ROI (segmentation)"
-        assert self.v7_annotations.available_classes[0].annotation_type == AnnotationType.BOX
-        assert self.v7_annotations.available_classes[1].label == "stroma (area)"
-        assert self.v7_annotations.available_classes[1].annotation_type == AnnotationType.POLYGON
-        assert self.v7_annotations.available_classes[2].label == "lymphocyte (cell)"
-        assert self.v7_annotations.available_classes[2].annotation_type == AnnotationType.POINT
-        assert self.v7_annotations.available_classes[3].label == "tumor (cell)"
-        assert self.v7_annotations.available_classes[3].annotation_type == AnnotationType.BOX
-        assert self.v7_annotations.available_classes[4].label == "tumor (area)"
-        assert self.v7_annotations.available_classes[4].annotation_type == AnnotationType.POLYGON
+        assert AnnotationClass(label="ROI (segmentation)", annotation_type=AnnotationType.BOX) in self.v7_annotations
+        assert AnnotationClass(label="stroma (area)", annotation_type=AnnotationType.POLYGON) in self.v7_annotations
+        assert AnnotationClass(label="lymphocyte (cell)", annotation_type=AnnotationType.POINT) in self.v7_annotations
+        assert AnnotationClass(label="tumor (cell)", annotation_type=AnnotationType.BOX) in self.v7_annotations
+        assert AnnotationClass(label="tumor (area)", annotation_type=AnnotationType.POLYGON) in self.v7_annotations
+
+        # assert self.v7_annotations.available_classes[0].label == "ROI (segmentation)"
+        # assert self.v7_annotations.available_classes[0].annotation_type == AnnotationType.BOX
+        # assert self.v7_annotations.available_classes[1].label == "stroma (area)"
+        # assert self.v7_annotations.available_classes[1].annotation_type == AnnotationType.POLYGON
+        # assert self.v7_annotations.available_classes[2].label == "lymphocyte (cell)"
+        # assert self.v7_annotations.available_classes[2].annotation_type == AnnotationType.POINT
+        # assert self.v7_annotations.available_classes[3].label == "tumor (cell)"
+        # assert self.v7_annotations.available_classes[3].annotation_type == AnnotationType.BOX
+        # assert self.v7_annotations.available_classes[4].label == "tumor (area)"
+        # assert self.v7_annotations.available_classes[4].annotation_type == AnnotationType.POLYGON
 
         assert self.v7_annotations.bounding_box == (
             (15291.49, 18094.48),

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -5,7 +5,6 @@ import json
 import pathlib
 import pickle
 import tempfile
-from copy import copy, deepcopy
 
 import pytest
 import shapely.geometry
@@ -205,8 +204,6 @@ class TestAnnotations:
             pickled_polygon_file.seek(0)
             loaded_solid_polygon = pickle.load(pickled_polygon_file)
         assert dlup_solid_polygon == loaded_solid_polygon
-        assert dlup_solid_polygon == copy(dlup_solid_polygon)
-        assert dlup_solid_polygon == deepcopy(dlup_solid_polygon)
 
         with tempfile.NamedTemporaryFile(suffix=".pkl", mode="w+b") as pickled_polygon_file:
             pickle.dump(dlup_polygon_with_holes, pickled_polygon_file)
@@ -214,8 +211,6 @@ class TestAnnotations:
             pickled_polygon_file.seek(0)
             loaded_polygon_with_holes = pickle.load(pickled_polygon_file)
         assert dlup_polygon_with_holes == loaded_polygon_with_holes
-        assert dlup_polygon_with_holes == copy(dlup_polygon_with_holes)
-        assert dlup_polygon_with_holes == deepcopy(dlup_polygon_with_holes)
 
     def test_point_pickling(self):
         annotation_class = AnnotationClass(

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -8,6 +8,7 @@ import tempfile
 
 import pytest
 import shapely.geometry
+from copy import copy, deepcopy
 from shapely import Point as ShapelyPoint
 from shapely import Polygon as ShapelyPolygon
 
@@ -153,6 +154,7 @@ class TestAnnotations:
         )
 
         region = self.v7_annotations.read_region((15300, 19000), 1.0, (2500.0, 2500.0))
+        # FIXME: Is this right? These are the original values
         expected_output = [
             (6250000.0, "BOX", "ROI (segmentation)"),
             (1616768.0657540846, "POLYGON", "stroma (area)"),
@@ -191,6 +193,8 @@ class TestAnnotations:
             pickled_polygon_file.seek(0)
             loaded_solid_polygon = pickle.load(pickled_polygon_file)
         assert dlup_solid_polygon == loaded_solid_polygon
+        assert dlup_solid_polygon == copy(dlup_solid_polygon)
+        assert dlup_solid_polygon == deepcopy(dlup_solid_polygon)
 
         with tempfile.NamedTemporaryFile(suffix=".pkl", mode="w+b") as pickled_polygon_file:
             pickle.dump(dlup_polygon_with_holes, pickled_polygon_file)
@@ -198,6 +202,8 @@ class TestAnnotations:
             pickled_polygon_file.seek(0)
             loaded_polygon_with_holes = pickle.load(pickled_polygon_file)
         assert dlup_polygon_with_holes == loaded_polygon_with_holes
+        assert dlup_polygon_with_holes == copy(dlup_polygon_with_holes)
+        assert dlup_polygon_with_holes == deepcopy(dlup_polygon_with_holes)
 
     def test_point_pickling(self):
         annotation_class = AnnotationClass(

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -139,24 +139,27 @@ class TestAnnotations:
     def test_read_darwin_v7(self):
         if not DARWIN_SDK_AVAILABLE:
             return None
-        print(self.v7_annotations.available_classes)
         assert len(self.v7_annotations.available_classes) == 5
-        assert AnnotationClass(label="ROI (segmentation)", annotation_type=AnnotationType.BOX) in self.v7_annotations
-        assert AnnotationClass(label="stroma (area)", annotation_type=AnnotationType.POLYGON) in self.v7_annotations
-        assert AnnotationClass(label="lymphocyte (cell)", annotation_type=AnnotationType.POINT) in self.v7_annotations
-        assert AnnotationClass(label="tumor (cell)", annotation_type=AnnotationType.BOX) in self.v7_annotations
-        assert AnnotationClass(label="tumor (area)", annotation_type=AnnotationType.POLYGON) in self.v7_annotations
-
-        # assert self.v7_annotations.available_classes[0].label == "ROI (segmentation)"
-        # assert self.v7_annotations.available_classes[0].annotation_type == AnnotationType.BOX
-        # assert self.v7_annotations.available_classes[1].label == "stroma (area)"
-        # assert self.v7_annotations.available_classes[1].annotation_type == AnnotationType.POLYGON
-        # assert self.v7_annotations.available_classes[2].label == "lymphocyte (cell)"
-        # assert self.v7_annotations.available_classes[2].annotation_type == AnnotationType.POINT
-        # assert self.v7_annotations.available_classes[3].label == "tumor (cell)"
-        # assert self.v7_annotations.available_classes[3].annotation_type == AnnotationType.BOX
-        # assert self.v7_annotations.available_classes[4].label == "tumor (area)"
-        # assert self.v7_annotations.available_classes[4].annotation_type == AnnotationType.POLYGON
+        assert (
+            AnnotationClass(label="ROI (segmentation)", annotation_type=AnnotationType.BOX, color=(143, 0, 255))
+            in self.v7_annotations
+        )
+        assert (
+            AnnotationClass(label="stroma (area)", annotation_type=AnnotationType.POLYGON, color=(0, 236, 123))
+            in self.v7_annotations
+        )
+        assert (
+            AnnotationClass(label="lymphocyte (cell)", annotation_type=AnnotationType.POINT, color=(0, 236, 123))
+            in self.v7_annotations
+        )
+        assert (
+            AnnotationClass(label="tumor (cell)", annotation_type=AnnotationType.BOX, color=(255, 46, 0))
+            in self.v7_annotations
+        )
+        assert (
+            AnnotationClass(label="tumor (area)", annotation_type=AnnotationType.POLYGON, color=(255, 46, 0))
+            in self.v7_annotations
+        )
 
         assert self.v7_annotations.bounding_box == (
             (15291.49, 18094.48),
@@ -164,7 +167,6 @@ class TestAnnotations:
         )
 
         region = self.v7_annotations.read_region((15300, 19000), 1.0, (2500.0, 2500.0))
-        # FIXME: Is this right? These are the original values
         expected_output = [
             (6250000.0, "BOX", "ROI (segmentation)"),
             (1616768.0657540846, "POLYGON", "stroma (area)"),
@@ -233,7 +235,7 @@ class TestAnnotations:
         annotations = self.asap_annotations.copy()
         annotations.filter(["healthy glands"])
         assert len(annotations._layers) == 1
-        assert annotations.available_classes[0].label == "healthy glands"
+        assert "healthy glands" in annotations
 
         annotations.filter(["non-existing"])
         assert len(annotations._layers) == 0

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -8,8 +8,6 @@ import tempfile
 
 import pytest
 import shapely.geometry
-from shapely import Point as ShapelyPoint
-from shapely import Polygon as ShapelyPolygon
 
 from dlup.annotations import AnnotationClass, AnnotationType, Point, Polygon, WsiAnnotations, shape
 from dlup.utils.imports import DARWIN_SDK_AVAILABLE
@@ -195,8 +193,7 @@ class TestAnnotations:
         exterior = [(0, 0), (4, 0), (4, 4), (0, 4)]
         hole1 = [(1, 1), (2, 1), (2, 2), (1, 2)]
         hole2 = [(3, 3), (3, 3.5), (3.5, 3.5), (3.5, 3)]
-        shapely_polygon_with_holes = ShapelyPolygon(exterior, [hole1, hole2])
-        dlup_polygon_with_holes = Polygon(shapely_polygon_with_holes, a_cls=annotation_class)
+        dlup_polygon_with_holes = Polygon(exterior, [hole1, hole2], a_cls=annotation_class)
         dlup_solid_polygon = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)], a_cls=annotation_class)
         with tempfile.NamedTemporaryFile(suffix=".pkl", mode="w+b") as pickled_polygon_file:
             pickle.dump(dlup_solid_polygon, pickled_polygon_file)
@@ -216,11 +213,9 @@ class TestAnnotations:
         annotation_class = AnnotationClass(
             label="example", annotation_type=AnnotationType.POINT, color=(255, 0, 0), z_index=None
         )
-        coordinates = [(1, 2)]
-        shapely_point = ShapelyPoint(coordinates)
-        dlup_point = Point(shapely_point, a_cls=annotation_class)
+        dlup_point = Point([(1, 2)], a_cls=annotation_class)
         with tempfile.NamedTemporaryFile(suffix=".pkl", mode="w+b") as pickled_point_file:
-            pickle.dump(shapely_point, pickled_point_file)
+            pickle.dump(dlup_point, pickled_point_file)
             pickled_point_file.flush()
             pickled_point_file.seek(0)
             loaded_point = pickle.load(pickled_point_file)

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -127,6 +127,10 @@ class TestAnnotations:
             assert region == []
 
     def test_copy(self):
+        # FIXME: deepcopy and copy are different. filter gives different classes for a shallow copy because the _layers
+        # and available_classes get overwritten with a new instances and the original instances do not get changed.
+        # If we modify _layers and _available_classes directly, this test would assert that they are the same and a
+        # copy.deepcopy(self.asap_annotations) would assert they are different
         copied_annotations = self.asap_annotations.copy()
         # Now we can change a parameter
         copied_annotations.filter([""])

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -53,6 +53,14 @@ class TestAnnotations:
     _v7_annotations = None
     _v7_raster_annotations = None
 
+    additinoaL_point_a_cls = AnnotationClass(label="example", annotation_type=AnnotationType.POINT, color=(255, 0, 0))
+    additional_point = Point((1, 2), a_cls=additinoaL_point_a_cls)
+
+    additional_polygon_a_cls = AnnotationClass(
+        label="example", annotation_type=AnnotationType.POLYGON, color=(255, 0, 0), z_index=1
+    )
+    additional_polygon = Polygon([(0, 0), (4, 0), (4, 4), (0, 4)], a_cls=additional_polygon_a_cls)
+
     @property
     def v7_annotations(self):
         if self._v7_annotations is None:
@@ -229,3 +237,111 @@ class TestAnnotations:
 
         annotations.filter(["non-existing"])
         assert len(annotations._layers) == 0
+
+    def test_length(self):
+        annotations = self.geojson_annotations
+        assert len(annotations._layers) == len(annotations)
+
+    def test_dunder_add_methods_with_point(self):
+        annotations = self.geojson_annotations.copy()
+        initial_annotations_id = id(annotations)
+        initial_length = len(annotations)
+
+        # __add__
+        new_annotations = annotations + self.additional_point
+        assert initial_annotations_id != id(new_annotations)
+        assert initial_length + 1 == len(new_annotations)
+        assert self.additional_point in new_annotations
+
+        # __radd__
+        new_annotations = self.additional_point + annotations
+        assert initial_annotations_id != id(new_annotations)
+        assert initial_length + 1 == len(new_annotations)
+        assert self.additional_point in new_annotations
+        with pytest.raises(TypeError):
+            self.additional_point += annotations
+
+        # __iadd__
+        annotations += self.additional_point
+        assert initial_annotations_id == id(annotations)
+        assert initial_length + 1 == len(annotations)
+        assert self.additional_point in annotations
+
+    def test_add_with_polygon(self):
+        annotations = self.geojson_annotations.copy()
+        initial_annotations_id = id(annotations)
+        initial_length = len(annotations)
+
+        # __add__
+        new_annotations = annotations + self.additional_polygon
+        assert initial_annotations_id != id(new_annotations)
+        assert initial_length + 1 == len(new_annotations)
+        assert self.additional_polygon in new_annotations
+
+        # __radd__
+        new_annotations = self.additional_polygon + annotations
+        assert initial_annotations_id != id(new_annotations)
+        assert initial_length + 1 == len(new_annotations)
+        assert self.additional_polygon in new_annotations
+        with pytest.raises(TypeError):
+            self.additional_polygon += annotations
+
+        # __iadd__
+        annotations += self.additional_polygon
+        assert initial_annotations_id == id(annotations)
+        assert initial_length + 1 == len(annotations)
+        assert self.additional_polygon in annotations
+
+    def test_add_with_list(self):
+        annotations = self.geojson_annotations.copy()
+        initial_annotations_id = id(annotations)
+        initial_length = len(annotations)
+
+        # __add__
+        new_annotations = annotations + [self.additional_point, self.additional_polygon]
+        assert initial_annotations_id != id(new_annotations)
+        assert initial_length + 2 == len(new_annotations)
+        assert self.additional_polygon in new_annotations
+        assert self.additional_point in new_annotations
+
+        # __radd__
+        _annotations_list = [self.additional_point, self.additional_polygon]
+        with pytest.raises(TypeError):
+            new_annotations = _annotations_list + annotations
+
+        _annotations_list = [self.additional_point, self.additional_polygon]
+        with pytest.raises(TypeError):
+            _annotations_list += annotations
+
+        # __iadd__
+        annotations += [self.additional_point, self.additional_polygon]
+        assert initial_annotations_id == id(annotations)
+        assert initial_length + 2 == len(annotations)
+        assert all(ann in new_annotations for ann in annotations)
+
+    def test_add_with_wsi_annotations(self):
+        annotations = self.geojson_annotations.copy()
+        other_annotations = self.geojson_annotations.copy()
+        initial_annotations_id = id(annotations)
+        initial_length = len(annotations)
+
+        # __add__
+        new_annotations = annotations + other_annotations
+        assert initial_annotations_id != id(new_annotations)
+        assert len(annotations) + len(other_annotations) == len(new_annotations)
+        assert all(ann in new_annotations for ann in annotations)
+
+        # __iadd__
+        annotations += other_annotations
+        assert initial_annotations_id == id(annotations)
+        assert initial_length + len(other_annotations) == len(annotations)
+        assert all(ann in annotations for ann in other_annotations)
+
+    def test_add_with_invalid_type(self):
+        annotations = self.geojson_annotations.copy()
+        with pytest.raises(TypeError):
+            _ = annotations + "invalid type"
+        with pytest.raises(TypeError):
+            annotations += "invalid type"
+        with pytest.raises(TypeError):
+            _ = "invalid type" + annotations

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -78,7 +78,8 @@ def test_convert_annotations_polygons_with_floats(top_add, bottom_add):
 
 def test_convert_annotations_label_not_present():
     polygon = Polygon(
-        [(1, 1), (1, 7), (7, 7), (7, 1)], a_cls=AnnotationClass(label="polygon", annotation_type=AnnotationType.POLYGON)
+        [(1, 1), (1, 7), (7, 7), (7, 1)],
+        a_cls=AnnotationClass(label="polygon", annotation_type=AnnotationType.POLYGON),
     )
     with pytest.raises(ValueError, match="Label polygon is not in the index map {}"):
         convert_annotations([polygon], (10, 10), {})
@@ -101,15 +102,11 @@ def _create_complex_polygons():
 
     shell1 = [(4, 4), (4, 9), (9, 9), (9, 4)]
     holes1 = [[(5, 5), (5, 7), (7, 7), (7, 5)], [(7, 7), (5, 9), (5, 9), (9, 9)]]
-    spolygon = ShapelyPolygon(
-        shell1, holes=holes1
-    )
+    spolygon = ShapelyPolygon(shell1, holes=holes1)
     polygon1 = Polygon(spolygon, a_cls=AnnotationClass(label="polygon2", annotation_type=AnnotationType.POLYGON))
-    
+
     shell_roi = [(3, 3), (3, 6), (6, 6), (6, 3)]
-    roi = Polygon(
-        shell_roi, a_cls=AnnotationClass(label="roi", annotation_type=AnnotationType.POLYGON)
-    )
+    roi = Polygon(shell_roi, a_cls=AnnotationClass(label="roi", annotation_type=AnnotationType.POLYGON))
 
     target = np.asarray(
         [
@@ -144,7 +141,8 @@ def test_convert_annotations_multiple_polygons_and_holes():
 
 def test_convert_annotations_out_of_bounds():
     polygon = Polygon(
-        [(2, 2), (2, 11), (11, 11), (11, 2)], a_cls=AnnotationClass(label="polygon1", annotation_type=AnnotationType.POLYGON)
+        [(2, 2), (2, 11), (11, 11), (11, 2)],
+        a_cls=AnnotationClass(label="polygon1", annotation_type=AnnotationType.POLYGON),
     )
     points, mask, roi_mask = convert_annotations([polygon], (10, 10), {"polygon1": 2})
 
@@ -204,11 +202,13 @@ class TestRenameLabels:
 
     def test_remap_polygon(self, transformer1):
         old_annotation = Polygon(
-            [(2, 2), (2, 8), (8, 8), (8, 2)], a_cls=AnnotationClass(label="old_name", annotation_type=AnnotationType.POLYGON)
+            [(2, 2), (2, 8), (8, 8), (8, 2)],
+            a_cls=AnnotationClass(label="old_name", annotation_type=AnnotationType.POLYGON),
         )
 
         random_box = Polygon(
-            [(2, 2), (2, 8), (8, 8), (8, 2)], a_cls=AnnotationClass(label="some_box", annotation_type=AnnotationType.BOX)
+            [(2, 2), (2, 8), (8, 8), (8, 2)],
+            a_cls=AnnotationClass(label="some_box", annotation_type=AnnotationType.BOX),
         )
 
         random_point = Point((1, 1), a_cls=AnnotationClass(label="some_point", annotation_type=AnnotationType.POINT))


### PR DESCRIPTION
This PR implements some new features, refactors the annotations code and aims to simplify it. Most importantly are the addition of `AnnotatedGeometry` and new dunder methods in `WsiAnnotations`. It is an initial idea and implementation for features, which could be useful. It would be great to further discuss these ideas and get feedback.

### Changes
- Added class `AnnotatedGeometry` to inheret from for `Point` and `Polgyon` classes. This simplifies code for the `Point` and `Polygon` classes. This also allows us to extend to new annotated geometries for `MultiPolygon` or `MultiPoint` with our own annotation classes.
- Added `__iadd__` and `__isub__` methods for `AnnotatedGeometry` that raises a `TypeError`.
- Modified `__new__` function to be in line with shapely. This allows polygons (with holes) to be created directly as a dlup `Polygon`. 
- Combined `annotation_type` lookup into a single enum for ASAP, V7 and GeoJSON.
- Added `annotation_type` to `DarwinV7Metadata` lookup for colors. This is useful when a class for keypoints and polygons have the same label, but different colors. In that case `annotation_type` is needed to retrieve the correct color.
- Simplified `_is_rectangle` and added `_is_alligned_rectangle` for determining unrotated bounding boxes.
- Use of Shapely affinity transformation instead of `transform`
- Added a utils file with utility functions for annotations. Perhaps, `DarwinV7Metadata` and `_get_v7_metadata` can also be moved here. 
- Export z-index into geometry properties class. (Still being discussed here: #240)
- Slightly improved type hinting.
- Incorporated `_ComplexDarwinPolygonWrapper` directly into `_parse_darwin_complex_polygon`.
- Fixed test_point_pickling in test_annotations.py by pickling dlup point instead of ShapelyPoint

#### Changes made to `WsiAnnotations`:
- Changed `_available_labels` to use set instead of list for efficiency	
- Added sorting layers in place to `WsiAnnotations`
- Directly use `shapely.affinity.affine_transform` in the `read_region` function.
- Extended `WsiAnnotations` dunder methods:
	+ Added `__len__` as length of _layers
	+ Extend `__contains__` to check if a `Point` or `Polygon` is in layers
	+ Implemented `__add__`, `__iadd__` and `__radd__` for addition, in-place addition and right side addition.
	+ Added templates for methods `__sub__`, `__isub__` and `__rsub__`
- Added tests for dunder methods.

### Further changes and comments:
- Define behavior for `__radd__` of lists of Polygons and Points
- Add same functionalities for subtracting from `WsiAnnotations`.
- Write more tests for (new) dunder methods
- Move `DarwinV7Metadata` and `_get_v7_metadata` to utils file. This is not possible now because `AnnotationType` is added to the metadata.
- Move other helper function and classes (such as `_geometry_to_geojson`, `GeoJsonDict`, `CoordinatesDict`, `_is_rectangle`, `_is_allagined_rectangle`) to util file to simplify code.
- The `WsiAnotations.copy` function uses deepcopy. The test and behavior for this method are not completely in line with the shallow and deep copy operations defined in the standard python library. Another `__copy__` and `__deepcopy__` method could be added.